### PR TITLE
removal of bibliographies now decoupled from text extraction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile 'org.reflections:reflections:0.9.9'
     compile 'org.apache.commons:commons-lang3:3.0'
     compile 'commons-io:commons-io:2.4'
+    compile 'org.apache.commons:commons-collections4:4.0'
 
     // Unit testing
     testCompile 'junit:junit:4.6'

--- a/src/main/java/io/github/infolis/algorithm/BaseAlgorithm.java
+++ b/src/main/java/io/github/infolis/algorithm/BaseAlgorithm.java
@@ -8,7 +8,6 @@ import io.github.infolis.datastore.TempFileResolver;
 import io.github.infolis.model.Execution;
 import io.github.infolis.model.ExecutionStatus;
 import io.github.infolis.util.SerializationUtils;
-import java.text.DateFormat;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -34,7 +33,7 @@ public abstract class BaseAlgorithm implements Algorithm {
     public static Map<String, Class<? extends BaseAlgorithm>> algorithms = new HashMap<>();
 
     static {
-        algorithms.put(TextExtractorAlgorithm.class.getSimpleName(), TextExtractorAlgorithm.class);
+        algorithms.put(TextExtractor.class.getSimpleName(), TextExtractor.class);
     }
 
     public BaseAlgorithm(

--- a/src/main/java/io/github/infolis/algorithm/BibliographyExtractor.java
+++ b/src/main/java/io/github/infolis/algorithm/BibliographyExtractor.java
@@ -1,0 +1,200 @@
+package io.github.infolis.algorithm;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+
+import io.github.infolis.InfolisConfig;
+import io.github.infolis.datastore.DataStoreClient;
+import io.github.infolis.datastore.FileResolver;
+import io.github.infolis.model.ExecutionStatus;
+import io.github.infolis.model.entity.InfolisFile;
+import io.github.infolis.util.RegexUtils;
+import io.github.infolis.util.SerializationUtils;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.net.MediaType;
+
+/**
+ * 
+ * @author kata
+ * 
+ */
+public class BibliographyExtractor extends BaseAlgorithm {
+
+    public BibliographyExtractor(DataStoreClient inputDataStoreClient, DataStoreClient outputDataStoreClient,
+            FileResolver inputFileResolver, FileResolver outputFileResolver) {
+        super(inputDataStoreClient, outputDataStoreClient, inputFileResolver, outputFileResolver);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(BibliographyExtractor.class);
+    BreakIterator sentenceIterator = BreakIterator.getSentenceInstance(Locale.ROOT);   
+    
+    /**
+     * Compute the ratio of numbers on page: a high number of numbers is assumed
+     * to be typical for bibliographies as they contain many years, page numbers
+     * and dates.
+     *
+     * @param sections	sections of text read from a text file
+     * @return text	of sections that are not classified as bibliography
+     * @throws IOException
+     */
+    protected String removeBibliography(List<String> sections) {
+        String textWithoutBib = "";
+        boolean startedBib = false;
+        for (int i = 0; i < sections.size(); i++) {
+        	String section = sections.get(i);
+            double numNumbers = 0.0;
+            double numDecimals = 0.0;
+            double numChars = section.length();
+            if (numChars == 0.0) continue;
+            // determine the amount of numbers (numeric and decimal)
+            Matcher matcherNumeric = RegexUtils.patternNumeric.matcher(section);
+            Matcher matcherDecimal = RegexUtils.patternDecimal.matcher(section);
+            while (matcherNumeric.find()) numNumbers++;
+            while (matcherDecimal.find()) numDecimals++;
+
+            boolean containsCueWord = false;
+            for (String s : InfolisConfig.getBibliographyCues()) {
+                if (section.contains(s)) {
+                    containsCueWord = true;
+                    break;
+                }
+            }
+            
+            // use hasBibNumberRatio_d method from python scripts
+            if (containsCueWord && ((numNumbers / numChars) >= 0.005) && ((numNumbers / numChars) <= 0.1)
+                    && ((numDecimals / numChars) <= 0.004)) {
+                startedBib = true;
+                continue;
+            }
+
+            if (startedBib) {
+                if (((numNumbers / numChars) >= 0.01) && ((numNumbers / numChars) <= 0.1)
+                        && ((numDecimals / numChars) <= 0.004)) {
+                } else {
+                    textWithoutBib += section;
+                }
+            } else {
+                if (((numNumbers / numChars) >= 0.008) && ((numNumbers / numChars) <= 0.1)
+                        && ((numDecimals / numChars) <= 0.004)) {
+                } else {
+                    textWithoutBib += section;
+                }
+            }
+        }
+        return textWithoutBib;
+    }
+    
+    protected List<String> tokenizeSections(String text) {
+    	List<String> sections = new ArrayList<String>();
+    	//TODO: Test optimal section size
+    	int sentencesPerSection = 10;
+    	int n = 0;
+    	String section = "";
+    	sentenceIterator.setText(text);
+    	int start = sentenceIterator.first();
+        for (int end = sentenceIterator.next();	end != BreakIterator.DONE; start = end, end = sentenceIterator.next()) {
+        	n++;
+        	if (n <= sentencesPerSection) section += System.getProperty("line.separator") + text.substring(start,end);
+        	else { 
+        		sections.add(section);
+        		section = "";
+        		n = 0;
+        	}
+        }
+        if (n != sentencesPerSection) sections.add(section);
+        for (String sec : sections) log.debug("----" + sec);
+        return sections;
+    }
+    
+    @Override
+    public void validate() throws IllegalAlgorithmArgumentException {
+        if (null == getExecution().getInputFiles()) {
+            throw new IllegalAlgorithmArgumentException(getClass(), "inputFiles",
+                    "Required parameter 'inputFiles' is missing!");
+        } else if (0 == getExecution().getInputFiles().size()) {
+            throw new IllegalAlgorithmArgumentException(getClass(), "inputFiles",
+                    "No values for parameter 'inputFiles'!");
+        }        
+    }
+    
+    
+    @Override
+    public void execute() { 
+    	int counter = 0;
+    	for (String inputFileURI : getExecution().getInputFiles()) {
+    		counter++;
+            log.debug(inputFileURI);
+            InfolisFile inputFile;
+            try {
+                inputFile = getInputDataStoreClient().get(InfolisFile.class, inputFileURI);
+            } catch (Exception e) {
+                fatal(log, "Could not retrieve file " + inputFileURI + ": " + e.getMessage());
+                getExecution().setStatus(ExecutionStatus.FAILED);
+                persistExecution();
+                return;
+            }
+            if (null == inputFile) {
+                fatal(log, "File was not registered with the data store: " + inputFileURI);
+                getExecution().setStatus(ExecutionStatus.FAILED);
+                persistExecution();
+                return;
+            }
+            if (null == inputFile.getMediaType() || !inputFile.getMediaType().equals(MediaType.PLAIN_TEXT_UTF_8.toString())) {
+                fatal(log, "File is not PLAIN_TEXT_UTF_8: " + inputFileURI);
+                getExecution().setStatus(ExecutionStatus.FAILED);
+                persistExecution();
+                return;
+            }
+            
+            debug(log, "Start removing bib from %s", inputFile);
+            String text = "";
+            try { text = FileUtils.readFileToString(new File(inputFile.getFileName()), "utf-8"); 
+            } catch (IOException e) { 
+            	fatal(log, "Error reading text file: " + e); 
+            	getExecution().setStatus(ExecutionStatus.FAILED);
+            	persistExecution();
+                return;
+            }
+            
+            List<String> inputSections = tokenizeSections(text);
+            text = removeBibliography(inputSections);
+            InfolisFile outFile = new InfolisFile();
+            //TODO: really overwrite file?
+            outFile.setFileName(inputFile.getFileName());
+            outFile.setMediaType("text/plain");
+            outFile.setMd5(SerializationUtils.getHexMd5(text));
+            outFile.setFileStatus("AVAILABLE");
+            
+            try {
+            	OutputStream outStream = getOutputFileResolver().openOutputStream(outFile);
+            	IOUtils.write(text, outStream);
+            } catch (IOException e) {
+            	fatal(log, "Error copying text to output stream: " + e);
+            	getExecution().setStatus(ExecutionStatus.FAILED);
+            	persistExecution();
+            	return;
+            }
+            
+            updateProgress(counter, getExecution().getInputFiles().size());
+            
+            debug(log, "Removed bibliography from file %s", outFile);
+            getOutputDataStoreClient().post(InfolisFile.class, outFile);
+            getExecution().getOutputFiles().add(outFile.getUri());
+        }
+        debug(log, "No of OutputFiles of this execution: %s", getExecution().getOutputFiles().size());
+        getExecution().setStatus(ExecutionStatus.FINISHED);
+        persistExecution();
+    }
+    
+}

--- a/src/main/java/io/github/infolis/algorithm/Learner.java
+++ b/src/main/java/io/github/infolis/algorithm/Learner.java
@@ -91,7 +91,7 @@ public class Learner extends BaseAlgorithm {
     private List<String> getTextDocuments(List<String> uris) {
     	Execution execution = new Execution();
     	execution.setInputFiles(uris);
-		execution.setAlgorithm(TextExtractorAlgorithm.class);
+		execution.setAlgorithm(TextExtractor.class);
 		this.getInputDataStoreClient().post(Execution.class, execution);
 		Algorithm algo = execution.instantiateAlgorithm(this.getInputDataStoreClient(), this.getOutputDataStoreClient(), this.getInputFileResolver(), this.getOutputFileResolver());
 		algo.run();

--- a/src/main/java/io/github/infolis/algorithm/PatternApplier.java
+++ b/src/main/java/io/github/infolis/algorithm/PatternApplier.java
@@ -155,7 +155,7 @@ public class PatternApplier extends BaseAlgorithm {
                 // if the input file is a PDF file, convert it
                 if (inputFile.getMediaType().startsWith("application/pdf")) {
                     Execution convertExec = new Execution();
-                    convertExec.setAlgorithm(TextExtractorAlgorithm.class);
+                    convertExec.setAlgorithm(TextExtractor.class);
                     convertExec.setInputFiles(Arrays.asList(inputFile.getUri()));
                     // TODO wire this more efficiently so files are stored temporarily
                     Algorithm algo = convertExec.instantiateAlgorithm(this);

--- a/src/main/java/io/github/infolis/algorithm/TextExtractor.java
+++ b/src/main/java/io/github/infolis/algorithm/TextExtractor.java
@@ -41,14 +41,14 @@ import com.google.common.net.MediaType;
  * @author kba
  * @author kata
  */
-public class TextExtractorAlgorithm extends BaseAlgorithm {
+public class TextExtractor extends BaseAlgorithm {
 
-    public TextExtractorAlgorithm(DataStoreClient inputDataStoreClient, DataStoreClient outputDataStoreClient,
+    public TextExtractor(DataStoreClient inputDataStoreClient, DataStoreClient outputDataStoreClient,
             FileResolver inputFileResolver, FileResolver outputFileResolver) {
         super(inputDataStoreClient, outputDataStoreClient, inputFileResolver, outputFileResolver);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(TextExtractorAlgorithm.class);
+    private static final Logger log = LoggerFactory.getLogger(TextExtractor.class);
 
     private static final PDFTextStripper stripper;
 
@@ -316,7 +316,7 @@ public class TextExtractorAlgorithm extends BaseAlgorithm {
             }
 
             Execution execution = new Execution();
-            execution.setAlgorithm(TextExtractorAlgorithm.class);
+            execution.setAlgorithm(TextExtractor.class);
             FileResolver ifr = FileResolverFactory.create(DataStoreStrategy.LOCAL);
             DataStoreClient idsc = DataStoreClientFactory.create(DataStoreStrategy.LOCAL);
             Algorithm algo = execution.instantiateAlgorithm(idsc, idsc, ifr, ifr);

--- a/src/main/java/io/github/infolis/algorithm/TextExtractor.java
+++ b/src/main/java/io/github/infolis/algorithm/TextExtractor.java
@@ -61,7 +61,8 @@ public class TextExtractor extends BaseAlgorithm {
     private String removeBibSection(String text) {
     	BibliographyExtractor bibExtractor = new BibliographyExtractor(
     			getInputDataStoreClient(), getOutputDataStoreClient(), getInputFileResolver(), getOutputFileResolver());
-    	return bibExtractor.removeBibliography(bibExtractor.tokenizeSections(text));
+    	//TODO: Test optimal section size
+    	return bibExtractor.removeBibliography(bibExtractor.tokenizeSections(text, 10));
     }
 
     public InfolisFile extract(InfolisFile inFile) throws IOException {

--- a/src/main/java/io/github/infolis/algorithm/TextExtractorAlgorithm.java
+++ b/src/main/java/io/github/infolis/algorithm/TextExtractorAlgorithm.java
@@ -74,7 +74,7 @@ public class TextExtractorAlgorithm extends BaseAlgorithm {
         outFile.setFileName(outFileName);
         outFile.setMediaType("text/plain");
         
-        if (getExecution().getOverwriteTextfiles()) {
+        if (getExecution().getOverwriteTextfiles() == false) {
 	        File _outFile = new File(outFileName);
 	        if (_outFile.exists()) { 
 	        	debug(log, "File exists: %s, skipping text extraction for %s", _outFile, inFile);

--- a/src/main/java/io/github/infolis/commandLine/CommandLineExecuter.java
+++ b/src/main/java/io/github/infolis/commandLine/CommandLineExecuter.java
@@ -289,10 +289,12 @@ public class CommandLineExecuter {
                 }
             } else {
                 if (shouldConvertToText) {
-                    System.err.println("WARNING: Both --text-dir '" + textDir + "' and --pdf-dir '" + pdfDir
-                            + "' were specified. Will possibly clobber text files in conversion!");
-                    System.err.println("<Ctrl-C> to stop, <Enter> to continue");
-                    System.in.read();
+                    //System.err.println("WARNING: Both --text-dir '" + textDir + "' and --pdf-dir '" + pdfDir
+                    //        + "' were specified. Will possibly clobber text files in conversion!");
+                	System.err.println("WARNING: Both --text-dir '" + textDir + "' and --pdf-dir '" + pdfDir
+                            + "' were specified. Will ignore pdfs of existing text files.");
+                    //System.err.println("<Ctrl-C> to stop, <Enter> to continue");
+                    //System.in.read();
                     exec.setInputFiles(convertPDF(postFiles(pdfDir, "application/pdf")));
                 } else {
                     exec.setInputFiles(postFiles(textDir, "text/plain"));
@@ -337,6 +339,8 @@ public class CommandLineExecuter {
         convertExec.setAlgorithm(TextExtractorAlgorithm.class);
         convertExec.setOutputDirectory(textDir.toString());
         convertExec.setInputFiles(uris);
+        //TODO make configurable
+        convertExec.setOverwriteTextfiles(false);
         Algorithm algo = convertExec.instantiateAlgorithm(dataStoreClient, fileResolver);
         algo.run();
         return convertExec.getOutputFiles();

--- a/src/main/java/io/github/infolis/commandLine/CommandLineExecuter.java
+++ b/src/main/java/io/github/infolis/commandLine/CommandLineExecuter.java
@@ -3,7 +3,7 @@ package io.github.infolis.commandLine;
 import io.github.infolis.algorithm.Algorithm;
 import io.github.infolis.algorithm.Indexer;
 import io.github.infolis.algorithm.SearchTermPosition;
-import io.github.infolis.algorithm.TextExtractorAlgorithm;
+import io.github.infolis.algorithm.TextExtractor;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.DataStoreClientFactory;
 import io.github.infolis.datastore.DataStoreStrategy;
@@ -336,7 +336,7 @@ public class CommandLineExecuter {
      */
     private List<String> convertPDF(List<String> uris) {
         Execution convertExec = new Execution();
-        convertExec.setAlgorithm(TextExtractorAlgorithm.class);
+        convertExec.setAlgorithm(TextExtractor.class);
         convertExec.setOutputDirectory(textDir.toString());
         convertExec.setInputFiles(uris);
         //TODO make configurable

--- a/src/main/java/io/github/infolis/model/Execution.java
+++ b/src/main/java/io/github/infolis/model/Execution.java
@@ -4,7 +4,7 @@ import io.github.infolis.algorithm.Algorithm;
 import io.github.infolis.algorithm.FederatedSearcher;
 import io.github.infolis.algorithm.Learner;
 import io.github.infolis.algorithm.SearchTermPosition;
-import io.github.infolis.algorithm.TextExtractorAlgorithm;
+import io.github.infolis.algorithm.TextExtractor;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.FileResolver;
 
@@ -170,7 +170,7 @@ public class Execution extends BaseModel {
 	/**
 	 * Output directory of Indexer and TextExtractor. 
          * 
-	 * {@link TextExtractorAlgorithm} {@link Indexer} {@link Bootstrapping} 
+	 * {@link TextExtractor} {@link Indexer} {@link Bootstrapping} 
 	 */
 	private String outputDirectory = "";
 
@@ -379,12 +379,12 @@ public class Execution extends BaseModel {
 	private List<String> tags;
 	
 	/**
-	 * Flag used by TextExtractorAlgorithm: if set to false, pdfs for which corresponding text 
+	 * Flag used by TextExtractor: if set to false, pdfs for which corresponding text 
 	 * files already exist in the specified text directory will not be converted again, instead 
 	 * the existing text files will be returned as InfolisFile instances. If set to true, all 
 	 * pdfs will be converted regardless of any existing files in the text directory. 
 	 * Default: true.
-	 * {@link TextExtractorAlgorithm}
+	 * {@link TextExtractor}
 	 */
 	private boolean overwriteTextfiles = true;
 

--- a/src/main/java/io/github/infolis/model/Execution.java
+++ b/src/main/java/io/github/infolis/model/Execution.java
@@ -377,6 +377,16 @@ public class Execution extends BaseModel {
          * 
 	 */
 	private List<String> tags;
+	
+	/**
+	 * Flag used by TextExtractorAlgorithm: if set to false, pdfs for which corresponding text 
+	 * files already exist in the specified text directory will not be converted again, instead 
+	 * the existing text files will be returned as InfolisFile instances. If set to true, all 
+	 * pdfs will be converted regardless of any existing files in the text directory. 
+	 * Default: true.
+	 * {@link TextExtractorAlgorithm}
+	 */
+	private boolean overwriteTextfiles = true;
 
 	//
 	//
@@ -658,6 +668,14 @@ public class Execution extends BaseModel {
     
     public void setProgress(long progress) {
         this.progress = progress;
+    }
+    
+    public void setOverwriteTextfiles(boolean overwriteTextfiles) {
+    	this.overwriteTextfiles = overwriteTextfiles;
+    }
+    
+    public boolean getOverwriteTextfiles() {
+    	return this.overwriteTextfiles;
     }
     
     public void setProperty(String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {

--- a/src/main/java/io/github/infolis/util/EvaluationUtils.java
+++ b/src/main/java/io/github/infolis/util/EvaluationUtils.java
@@ -1,0 +1,31 @@
+package io.github.infolis.util;
+
+import java.util.Collection;
+
+import org.apache.commons.collections4.CollectionUtils;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * @author kata
+ *
+ */
+public class EvaluationUtils {
+	
+	//private static final Logger log = LoggerFactory.getLogger(EvaluationUtils.class);
+	
+	public static double getPrecision(Collection<?> relevant, Collection<?> retrieved) {
+		Collection<?> intersect = CollectionUtils.intersection(relevant, retrieved);
+		return intersect.size() / (double) retrieved.size();
+	}
+	
+	public static double getRecall(Collection<?> relevant, Collection<?> retrieved) {
+		Collection<?> intersect = CollectionUtils.intersection(relevant, retrieved);
+		return intersect.size() / (double) relevant.size();
+	}
+	
+	public static double getF1Measure(double precision, double recall) {
+		return ((precision * recall) / (precision + recall)) * 2;
+	}
+}

--- a/src/test/java/io/github/infolis/algorithm/BibliographyExtractorTest.java
+++ b/src/test/java/io/github/infolis/algorithm/BibliographyExtractorTest.java
@@ -1,7 +1,147 @@
 package io.github.infolis.algorithm;
 
-import io.github.infolis.InfolisBaseTest;
+import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.infolis.InfolisBaseTest;
+import io.github.infolis.commandLine.CommandLineExecuterTest;
+import io.github.infolis.model.Execution;
+import io.github.infolis.model.entity.InfolisFile;
+import io.github.infolis.util.EvaluationUtils;
+import io.github.infolis.util.SerializationUtils;
+
+/**
+ * 
+ * @author kata
+ *
+ */
 public class BibliographyExtractorTest extends InfolisBaseTest {
 	
+	private static final Logger log = LoggerFactory.getLogger(BibliographyExtractorTest.class);
+	Path inputDir;
+	Path goldDir;
+	List<String> inputFiles;
+	List<String> goldFiles;
+	
+	public BibliographyExtractorTest() throws URISyntaxException, IOException {
+		inputDir = getResourcePath("/bibExtractor/test/");
+		goldDir = getResourcePath("/bibExtractor/gold/");
+		inputFiles = postFiles(inputDir, "text/plain");
+		goldFiles = postFiles(goldDir, "text/plain");
+	}
+	
+	private Path getResourcePath(String resName) throws URISyntaxException {
+    	URL resource = CommandLineExecuterTest.class.getResource(resName);
+    	log.debug("{}", resource);
+        return Paths.get(resource.toURI());
+    }
+	
+	public List<String> postFiles(Path dir, String mimetype) throws IOException {
+        List<InfolisFile> infolisFiles = new ArrayList<>();
+        DirectoryStream<Path> dirStream = Files.newDirectoryStream(dir);
+        for (Path file : dirStream) {
+            InfolisFile infolisFile = new InfolisFile();
+            InputStream inputStream = Files.newInputStream(file);
+            byte[] bytes = IOUtils.toByteArray(inputStream);
+            infolisFile.setMd5(SerializationUtils.getHexMd5(bytes));
+            infolisFile.setFileName(file.toString());
+            infolisFile.setMediaType(mimetype);
+            infolisFile.setFileStatus("AVAILABLE");
+            infolisFiles.add(infolisFile);
+        }
+        return dataStoreClient.post(InfolisFile.class, infolisFiles);
+    }
+	
+	public InfolisFile resolveFileUri(String uri) {
+		return dataStoreClient.get(InfolisFile.class, uri);
+	}
+	
+	@Test
+	public void testBibExtractor() throws URISyntaxException, IOException {
+		Execution exec = new Execution();
+		exec.setInputFiles(inputFiles);
+		exec.setAlgorithm(BibliographyExtractor.class);
+		exec.instantiateAlgorithm(dataStoreClient, fileResolver).run();
+		log.debug("output files: " + exec.getOutputFiles());
+		assertEquals(exec.getOutputFiles().size(), exec.getInputFiles().size());
+		// todo: check if files are written properly
+	}
+	
+	private Map<String, String> getGoldTexts() throws IOException {
+		Map<String, String> txtBibless = new HashMap<>();
+		for (String uri : goldFiles) { 
+			InfolisFile infolisFile = resolveFileUri(uri);
+			File file = new File(infolisFile.getFileName());
+			String text = FileUtils.readFileToString(file, "utf-8");
+			txtBibless.put(mapFilename(infolisFile), text);
+		}
+		return txtBibless;
+	}
+	
+	private String mapFilename(InfolisFile file) {
+		Path p = Paths.get(file.getFileName());
+		return p.getFileName().toString();
+	}
+	
+	private Map<String, String> getExtractedTexts() throws IOException {
+		BibliographyExtractor bibExtractor = new BibliographyExtractor(dataStoreClient, dataStoreClient, fileResolver, fileResolver);
+		Map<String, String> txtBibless = new HashMap<>();
+		for (String uri : inputFiles) { 
+			InfolisFile infolisFile = resolveFileUri(uri);
+			File file = new File(infolisFile.getFileName());
+			String text = FileUtils.readFileToString(file, "utf-8");
+			String bibless = bibExtractor.removeBibliography(bibExtractor.tokenizeSections(text, 10));
+			txtBibless.put(mapFilename(infolisFile), bibless);
+		}
+		return txtBibless;
+	}
+	
+	@Test
+	public void testRemoveBibliography() throws IOException {
+		Map<String, String> output = getExtractedTexts();
+		Map<String, String> gold = getGoldTexts();
+		double precision_avg = 0;
+		double recall_avg = 0;
+		BibliographyExtractor bibExtractor = new BibliographyExtractor(dataStoreClient, dataStoreClient, fileResolver, fileResolver);
+		for (String textfile : gold.keySet()) {
+			String goldText = gold.get(textfile);
+			String outputText = output.get(textfile);
+			log.debug("length of goldText: " + goldText.length());
+			log.debug("length of outputText: " + outputText.length());
+			Collection<String> goldSentences = bibExtractor.tokenizeSections(goldText, 1);
+			Collection<String> outputSentences = bibExtractor.tokenizeSections(outputText, 1);
+			double precision = EvaluationUtils.getPrecision(goldSentences, outputSentences);
+			double recall = EvaluationUtils.getRecall(goldSentences, outputSentences);
+			log.debug("precision: " + precision + " (" + textfile + ")");
+			log.debug("recall: " + recall + " (" + textfile + ")");
+			precision_avg += precision;
+			recall_avg += recall;
+		}
+		precision_avg = precision_avg / (double) gold.size();
+		recall_avg = recall_avg / (double) gold.size();
+		log.debug("Average precision: " + precision_avg);
+		log.debug("Average recall: " + recall_avg);
+		double f1 = EvaluationUtils.getF1Measure(precision_avg, recall_avg);
+		log.debug("F1-measure: " + f1);
+	}
 }

--- a/src/test/java/io/github/infolis/algorithm/BibliographyExtractorTest.java
+++ b/src/test/java/io/github/infolis/algorithm/BibliographyExtractorTest.java
@@ -1,0 +1,7 @@
+package io.github.infolis.algorithm;
+
+import io.github.infolis.InfolisBaseTest;
+
+public class BibliographyExtractorTest extends InfolisBaseTest {
+	
+}

--- a/src/test/java/io/github/infolis/algorithm/CitationMinerTest.java
+++ b/src/test/java/io/github/infolis/algorithm/CitationMinerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  *
  * @author domi
  */
-public class BibliographyExtractor extends InfolisBaseTest {
+public class CitationMinerTest extends InfolisBaseTest {
 
     @Test
     public void test() {

--- a/src/test/java/io/github/infolis/algorithm/ExampleChecker.java
+++ b/src/test/java/io/github/infolis/algorithm/ExampleChecker.java
@@ -254,7 +254,7 @@ public class ExampleChecker extends InfolisBaseTest {
             execution.getInputFiles().add(inFile.getUri());
 
         }
-        execution.setAlgorithm(TextExtractorAlgorithm.class);
+        execution.setAlgorithm(TextExtractor.class);
 
         Algorithm algo = execution.instantiateAlgorithm(dataStoreClient, fileResolver);
         algo.run();

--- a/src/test/java/io/github/infolis/algorithm/TextExtractorTest.java
+++ b/src/test/java/io/github/infolis/algorithm/TextExtractorTest.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TextExtractorAlgorithmTest extends InfolisBaseTest {
+public class TextExtractorTest extends InfolisBaseTest {
 
-	Logger log = LoggerFactory.getLogger(TextExtractorAlgorithmTest.class);
+	Logger log = LoggerFactory.getLogger(TextExtractorTest.class);
 	private byte[] pdfBytes;
 	Path tempFile;
 
@@ -47,7 +47,7 @@ public class TextExtractorAlgorithmTest extends InfolisBaseTest {
 
 		Execution execution = new Execution();
 		execution.getInputFiles().add(inFile.getUri());
-		execution.setAlgorithm(TextExtractorAlgorithm.class);
+		execution.setAlgorithm(TextExtractor.class);
 		dataStoreClient.post(Execution.class, execution);
 		Algorithm algo = execution.instantiateAlgorithm(dataStoreClient, dataStoreClient, fileResolver, fileResolver);
 		algo.run();
@@ -75,7 +75,7 @@ public class TextExtractorAlgorithmTest extends InfolisBaseTest {
 		assertNotNull(inFile.getUri());
 
 		execution.getInputFiles().add(inFile.getUri());
-		execution.setAlgorithm(TextExtractorAlgorithm.class);
+		execution.setAlgorithm(TextExtractor.class);
 
 		assertEquals(1, execution.getInputFiles().size());
 		dataStoreClient.post(Execution.class, execution);

--- a/src/test/java/io/github/infolis/model/ExecutionTest.java
+++ b/src/test/java/io/github/infolis/model/ExecutionTest.java
@@ -3,7 +3,7 @@ package io.github.infolis.model;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import io.github.infolis.InfolisBaseTest;
-import io.github.infolis.algorithm.TextExtractorAlgorithm;
+import io.github.infolis.algorithm.TextExtractor;
 import io.github.infolis.util.SerializationUtils;
 
 import java.util.Date;
@@ -23,7 +23,7 @@ public class ExecutionTest extends InfolisBaseTest {
 		// "false"));
 
 		Execution execution = new Execution();
-		execution.setAlgorithm(TextExtractorAlgorithm.class);
+		execution.setAlgorithm(TextExtractor.class);
 		execution.getInputFiles().add("urn:foo");
 		execution.getOutputFiles().add("urn:bar");
 		execution.setRemoveBib(true);

--- a/src/test/java/io/github/infolis/scheduler/ExecutionSchedulerTest.java
+++ b/src/test/java/io/github/infolis/scheduler/ExecutionSchedulerTest.java
@@ -3,7 +3,7 @@ package io.github.infolis.scheduler;
 import io.github.infolis.InfolisBaseTest;
 import io.github.infolis.algorithm.Algorithm;
 import io.github.infolis.algorithm.PatternApplier;
-import io.github.infolis.algorithm.TextExtractorAlgorithm;
+import io.github.infolis.algorithm.TextExtractor;
 import io.github.infolis.model.Execution;
 import io.github.infolis.model.entity.InfolisFile;
 import io.github.infolis.model.entity.InfolisPattern;
@@ -75,7 +75,7 @@ public class ExecutionSchedulerTest extends InfolisBaseTest {
         writeFile(inFile);
 
         execution.getInputFiles().add(inFile.getUri());
-        execution.setAlgorithm(TextExtractorAlgorithm.class);
+        execution.setAlgorithm(TextExtractor.class);
         dataStoreClient.post(Execution.class, execution);
         Algorithm algo = execution.instantiateAlgorithm(dataStoreClient, fileResolver);
         exe.execute(algo);

--- a/src/test/java/io/github/infolis/ws/server/ExecutorWebserviceTest.java
+++ b/src/test/java/io/github/infolis/ws/server/ExecutorWebserviceTest.java
@@ -3,7 +3,7 @@ package io.github.infolis.ws.server;
 import static org.junit.Assert.assertNotNull;
 import io.github.infolis.InfolisBaseTest;
 import io.github.infolis.InfolisConfig;
-import io.github.infolis.algorithm.TextExtractorAlgorithm;
+import io.github.infolis.algorithm.TextExtractor;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.DataStoreClientFactory;
 import io.github.infolis.datastore.DataStoreStrategy;
@@ -30,7 +30,7 @@ public class ExecutorWebserviceTest extends InfolisBaseTest {
         Assume.assumeNotNull(System.getProperty("infolisRemoteTest"));
 		
 		FormDataMultiPart fdm = new FormDataMultiPart();
-		fdm.field("algorithm", TextExtractorAlgorithm.class.getName());
+		fdm.field("algorithm", TextExtractor.class.getName());
 		WebTarget target = jerseyClient
 				.target(InfolisConfig.getFrontendURI())
 				.path("/execute");
@@ -53,7 +53,7 @@ public class ExecutorWebserviceTest extends InfolisBaseTest {
 
 		DataStoreClient centralClient = DataStoreClientFactory.create(DataStoreStrategy.CENTRAL);
 		Execution e = new Execution();
-		e.setAlgorithm(TextExtractorAlgorithm.class);
+		e.setAlgorithm(TextExtractor.class);
 		centralClient.post(Execution.class, e);
 		assertNotNull(e.getUri());
 		

--- a/src/test/resources/bibExtractor/gold/31452.txt
+++ b/src/test/resources/bibExtractor/gold/31452.txt
@@ -1,0 +1,453 @@
+www.ssoar.info
+Rezension: Sigrid Haunberger, 2011:
+Teilnahmeverweigerung in Panelstudien
+Lipps, Oliver
+Veröffentlichungsversion / Published Version
+Rezension / review
+Zur Verfügung gestellt in Kooperation mit / provided in cooperation with:
+GESIS - Leibniz-Institut für Sozialwissenschaften
+Empfohlene Zitierung / Suggested Citation:
+Lipps, Oliver (Rev.): Haunberger, Sigrid: Teilnahmeverweigerung in Panelstudien. Wiesbaden: VS Verl. für Sozialwiss.,
+2011. In: Methoden, Daten, Analysen (mda) 6 (2012), 1, pp. 49-53. URN: http://nbn-resolving.de/urn:nbn:de:0168-ssoar314523Nutzungsbedingungen:Dieser 
+Text wird unter einer CC BY Lizenz (Namensnennung) zur
+Verfügung gestellt. Nähere Auskünfte zu den CC-Lizenzen finden
+Sie hier:
+http://creativecommons.org/licenses/
+Terms of use:
+This document is made available under a CC BY Licence
+(Attribution). For more Information see:
+http://creativecommons.org/licenses/
+49 Rezensionen
+ringern sie den Umfang der realisierten 
+Stichprobe und bedingen daher größere 
+Stichprobenfehler. Last but not least ist sich 
+die mittlerweise recht umfangreiche Literatur 
+im Bereich der Nonresponseforschung in 
+der Einschätzung einig, dass Nonresponse 
+tendenziell zunimmt. 
+Die Einhaltung gewisser Grenzen von Nonresponse 
+stellt daher immer größere Anforderungen 
+an Erhebungsdesign und -ressourcen. 
+Dessen ungeachtet ist – wie die 
+Autorin des vorliegenden Buchs treffend 
+feststellt – „bezüglich der Erklärung systematischer 
+Ausfälle von Teilnehmern kaum 
+ein Fortschritt zu verzeichnen“ (S. 18). Dies 
+liegt daran, dass nach wie vor meist ausschließlich 
+sozio-demografische Variablen 
+wie Alter und Geschlecht nicht nur zur 
+Beschreibung, sondern auch zur Erklärung 
+von Nonresponse verwendet werden. Der 
+simple Grund ist, dass – wenn überhaupt – 
+von Nichtteilnehmern nur solche Variablen 
+bekannt sind; noch häufiger lediglich Randverteilungen. 
+Im Sinne einer Erklärung der 
+Prozesse und Mechanismen, die zur Teilnahme 
+oder Nichtteilnahme führen, sind 
+solche Variablen aber wenig geeignet.
+Sigrid Haunbergers im VS Verlag veröffentlichte 
+Dissertation ist ein äußerst lobenswertes 
+Plädoyer, sich für die Erklärung 
+von Nonresponse und Attrition von einer 
+solchen „Variablensoziologie“ zu lösen. Die 
+Autorin schlägt stattdessen zwei handlungstheoretische 
+Theorien vor: die Theory 
+of planned behavior (TOPB) und die Theory 
+of subjective expected utility (SEU). Sie 
+motiviert, operationalisiert und testet diese 
+empirisch anhand einer Stichprobe von Studierenden 
+mit Hilfe einer Onlineerhebung. 
+Insofern dürfte sich das Buch vor allem an 
+Erhebungsexperten aus Theorie und Praxis 
+richten, die Interesse an der Erklärung von 
+Nonresponse und Attrition haben. Speziell 
+eignet sich dieses Buch sehr gut als Grundlage 
+für weitergehende empirische Forschungsarbeiten 
+oder Experimente, Mechanismen 
+für Nonresponse auf der Grundlage der in 
+lungen auch Ansätze zur „Bestimmung des 
+Standorts und des weiteren Kurses“ (S. V). In 
+Bezug auf diese, im Geleitwort von Wilfried 
+Seidel genannte Zielsetzung wären eventuell 
+eine europäische oder internationale Situationsbetrachtung 
+oder Vergleiche mit anderen 
+statistischen Fachgesellschaften ein eigenes 
+Kapitel wert gewesen. Aufgrund der historischen 
+und fachlichen Synopsen ist der Band 
+aber nicht nur „ein Buch für die Freunde der 
+Statistik und der Deutschen Statistischen 
+Gesellschaft“ (S. IX), sondern auch für den 
+Einsatz in der universitären Lehre geeignet, 
+z. B. in Einführungen in die Wirtschafts- und 
+Sozialstatistik, und nicht zuletzt für alle 
+Anwender und Nutzer von statistischen Verfahren 
+und Daten interessant. 
+BernHard ScHimpl-neimannS, mannHeim
+* * * * *
+SiGrid HaunBerGer, 
+2011: Teilnahmeverweigerung 
+
+in Panelstudien. 
+VS-Verlag. ISBN: 
+978-3-531-17710-6, 
+254 Seiten, 39,95 
+EUR.
+Nicht (Nonresponse) bzw. nicht mehr (Attrition) 
+befragte Mitglieder von Zufallsstichproben 
+unterscheiden sich in aller Regel 
+systematisch von den Teilnehmern. Nonresponse 
+und Attrition sind wichtige, wenn 
+nicht sogar die wichtigsten Gründe für die 
+Verzerrung von Stichprobenparametern und 
+sta tis tischen Zusammenhängen. Zudem verMethoden 
+— Daten — Analysen · 2012, Jg. 6, Heft 150 
+dieser Arbeit verwendeten handlungstheoretischen 
+Theorien aufzudecken.
+Die einzelnen Kapitel bauen sinnvoll aufeinander 
+auf; das Buch liest sich leicht, was 
+auch einigen Wiederholungen von komplexeren 
+Sachverhalten zu verdanken ist. Die 
+Arbeit startet in Kapitel A mit einer sehr 
+guten Dokumentation der zunehmenden 
+Relevanz, Komplexität, und Popularität des 
+Themas Nonresponse. Die Autorin beanstandet, 
+dass sich in der umfangreichen 
+Literatur nur wenige Autoren finden, die 
+Non response nicht mittels soziodemografischen 
+(und anderen gerade zur Verfügung 
+stehenden Korrelaten) erklären, sondern 
+handlungstheoretisch fundierte Modelle 
+verwenden. Aber auch falls dies der Fall ist, 
+ist nach Ansicht der Autorin die Operationalisierung 
+der Theorie unzureichend. Die 
+geeignete Operationalisierung der beiden 
+Theorien stellt – neben dem empirischen 
+Test – in der vorliegenden Arbeit die Hauptzielsetzung 
+dar. Kapitel B bespricht Panelstudien 
+mit ihren analytischen Vorteilen, 
+erhebungsspezifischen Problemen und der 
+Vielschichtigkeit der Ausprägungen von 
+Nonresponse. Insbesondere können bei 
+Panelerhebungen Stichprobenmitglieder 
+nicht nur in der ersten Befragungswelle 
+ausfallen, sondern auch erst nach einer 
+gewissen Teilnahmedauer endgültig oder 
+temporär nicht (mehr) teilnehmen (Attrition). 
+Kapitel C diskutiert den aktuellen 
+Forschungsstand zu Non response, wobei 
+zwischen Nichterreichbarkeit und Verweigerung 
+differenziert wird. Diese Differenzierung 
+ist wichtig, da Motivation und 
+Hintergrund für diese beiden Ursachen 
+verschieden sind. Die Autorin kritisiert, 
+dass die verwendeten empirischen Modelle 
+zur Erklärung von Nichterreichbarkeit und 
+Verweigerung nur selten theoriegeleitet 
+sind und dementsprechend besonders bei 
+befragtenbezogenen Faktoren heterogene 
+Ergebnisse produzieren. Die „Theorien“ zur 
+Erklärung der Wirkungsmechanismen von 
+Nonresponse werden erläutert. Bemängelt 
+wird, dass sie meist bei Einzelaspekten 
+ansetzen (etwa Incentives) und oft die 
+Handlungsdispositionen der Stichprobenmitglieder 
+ignorieren. Die Autorin stellt 
+fest, dass Gründe für Verweigerungen oft 
+situativ sind. Dies vor allem aufgrund der 
+Tatsache, dass „eine Teilnahmeentscheidung 
+… aus einem Zustand der Indifferenz heraus 
+erfolgt“ (S. 96). Entsprechend müsste eine 
+handlungstheoretisch bedeutsame Erklärung 
+die subjektive Situation als relevante 
+Variable operationalisieren. In Kapitel D 
+werden die beiden handlungstheoretischen 
+Modelle des Teilnahmeverhaltens vorgestellt: 
+Die SEU enthält die Bewertungen von 
+und Erwartungen an möglichst alle zur Verfügung 
+stehenden Handlungsalternativen 
+als handlungserklärende Variablen; die TOPB 
+‚verhaltensbezogene Einstellung’, ‚subjektive 
+Norm’, und ‚wahrgenommene Verhaltenskontrolle’. 
+Wichtig sind die Prämissen, 
+dass Subjekte nicht voll rational/informiert 
+handeln, und dass das Handeln aus einer 
+bestimmten Situation heraus erklärt werden 
+muss. Zusätzlich spielen Routinen und 
+in ähnlichen Situationen bewährte Handlungsweisen 
+eine Rolle. Die Autorin erläutert 
+die Operationalisierung der beiden Theorien 
+zu quantitativen Modellen. Kapitel  E 
+beschreibt den empirischen Test der beiden 
+handlungstheoretischen Modelle. Die 
+Stichprobe besteht aus Studierenden der 
+Universität Bern aus verschiedenen, meist 
+sozialwissenschaftlichen Vorlesungen. Diese 
+werden zunächst in einer Paper  &  Pencil 
+„Null“messung über ihre Basischarakteristika 
+sowie – in zwei Gruppen randomisiert 
+– ihre handlungstheoretisch relevanten 
+Teilnahmedispositionen bezüglich 
+der Komponenten der SEU und der TOPB 
+befragt. Zudem werden die E-Mail Adressen 
+erfragt, wobei hier (Angabe oder eben 
+Nichtangabe der E-Mail Adresse) eine erste 
+Selektion erfolgt. Einige Zeit danach werden 
+die Befragten per E-Mail gebeten, bei einer 
+zwei Wellen umfassenden Online-Erhebung 
+über Drogen teilzunehmen. Hierbei erfolgt 
+die zweite und dritte Möglichkeit der Nonresponse. 
+In Kapitel F werden schließlich 
+die Ergebnisse interpretiert und Schluss51 Rezensionenfolgerungen 
+gezogen. Während mit beiden 
+Theorien die Teilnahmeintention relativ gut 
+erklärt wird, fällt die Erklärungskraft für 
+das tatsächliche Verhalten deutlich geringer 
+aus. Bei der TOPB sind es vor allem 
+modellexogene Faktoren, wie die subjektive 
+Entscheidungssicherheit und vergangene 
+Teilnahmehäufigkeit, bei der SEU Kostenbefürchtungen 
+und Situationsmerkmale, die 
+das tatsächliche Teilnahmeverhalten erklären. 
+Die Autorin folgert, dass die Theorien 
+trotz ihrer geringen Erklärungskraft zur 
+Erklärung des Teilnahmeverhaltens geeignet 
+sind. Sie schließt mit einer Kritik der 
+Resultate und der Diskussion weiterer Forschungsmöglichkeiten.Die 
+besonderen Stärken der Arbeit liegen in 
+der gut begründeten Kritik der konventionellen 
+Modelle zur Erklärung des Teilnahmeverhaltens 
+und der Motivation und Operationalisierung 
+der beiden Theorien SEU und 
+TOPB. Was ebenfalls bei einer Dissertation 
+nicht unbedingt erwartet werden kann, ist 
+der große Umfang der zitierten Literatur. Als 
+kleiner Wermutstropfen kann einzig festgehalten 
+werden, dass einzelne neuere Forschungsergebnisse 
+unerwähnt bleiben. So 
+hätte man etwa in Kapitel B, §1.2 einen Hinweis 
+darauf begrüßt, dass bei Stichprobenmitgliedern 
+gerade Veränderungen – die mit 
+Panelerhebungen ja insbesondere gemessen 
+werden sollen – zu erhöhter Attrition führen 
+(Ansätze z. B. in Voorpostel/Lipps 2011). 
+Dies zieht tendenziell eine Unterschätzung 
+von Veränderungen nach sich. Auch wäre 
+in Kapitel B, §2.6 (und auf S. 59) die Zitierung 
+der zwischenzeitlich etablierten Standardcodes 
+von finalen Ausfallsgründen der 
+American Association for Public Opinion 
+Research (AAPOR 2011) sinnvoll. Zudem 
+wäre eine stärkere Differenzierung von Nonresponse 
+bei Querschnittstudien einerseits, 
+die im Vergleich damit höhere Nonresponse 
+bei der ersten Welle einer Panelstudie andererseits, 
+und schließlich Panelattrition wünschenswert. 
+Auch wäre die Erwähnung von 
+Ansätzen zur Abschätzung von Verzerrungen 
+durch Nonresponse und Attrition auf 
+Individualebene mit Hilfe von Registerdaten 
+möglich (z. B. im CHINTEX Projekt mit ECHP 
+Daten, vgl. Ehling et al. 2003; Røed 2006). 
+Im Zusammenhang mit dem Vergleich von 
+Nonresponse Raten und Nonresponse Verzerrung 
+(Kapitel B, §3.2) hätte die Studie 
+von Groves und Peytcheva (2008) erwähnt 
+werden können. Zudem wäre ein Hinweis 
+auf R-Indikatoren (Schouten et al. 2009) 
+als Beispiel eines neuen Qualitätsindikators 
+für die Repräsentativität von Befragungen 
+willkommen. Entgegen der Kritik der mangelhaften 
+Dokumentation der Stichprobenrealisierung 
+bei Erhebungen gibt es Gegenbeispiele, 
+z. B. beim European Social Survey 
+(vergleiche die Methodenberichte zur Feldarbeit 
+im ESS auf der ESS Website http://ess.
+nsd.uib.no/). Im Kapitel C hätte eine kurze 
+Diskussion des Ausmaßes der Verzerrung 
+durch Nichtkontakt einerseits und Verweigerung 
+andererseits erfolgen können (etwa 
+Lynn/Clarke 2002). Am Ende hätte man sich 
+einen Anhang mit den verwendeten Fragebögen 
+(inklusive der Studienbeschreibung 
+bei der Nullmessung, vgl. S. 173) gewünscht; 
+möglicherweise auch ein Glossar.
+Allerdings muss ausdrücklich betont werden, 
+dass die vorliegende Arbeit meines 
+Erachtens die üblichen Anforderungen an 
+eine Dissertation sowohl in Bezug auf den 
+empirischen Teil als auch insbesondere auf 
+den theoretischen Teil weit mehr als erfüllt. 
+Etwaige Kritik muss im Kontext der insgesamt 
+sehr hohen Qualität der Arbeit und des 
+vermutlich geringen zur Verfügung stehenden 
+finanziellen Budgets für die Datenerhebung 
+beurteilt werden. Kleinere Mängel 
+im Text (Schreibfehler, Bezüge auf Tabelleninhalte, 
+vergessene Aufnahme zitierter 
+Literatur im Verzeichnis) und beim Fragebogen 
+(etwa Verlabelung der Endpunkte als 
+„sicher“, nicht nur als „sehr wahrscheinlich“ 
+wie auf S. 178) dürfen nicht überbewertet 
+werden. Ich erlaube mir lediglich eine 
+Überlegung dazu, warum die Modellvariablen 
+insbesondere auf das tatsächliche Teilnahmeverhalten 
+einen so geringen Einfluss 
+haben: Erstens werden in der Nullmessung 
+Methoden — Daten — Analysen · 2012, Jg. 6, Heft 152 
+die Effekte von fast allen befragungsbezogenen 
+Variablen (Ausnahme Incentives) 
+auf das selbst eingeschätzte hypothetische 
+Teilnahmeverhalten erhoben und nicht bei 
+der eigentlichen Befragung experimentell 
+variiert. Damit ist es wohl wahrscheinlich, 
+dass die Modellvariablen einen Einfluss auf 
+das intendierte Teilnahmeverhalten haben. 
+Der Einfluss auf das tatsächliche Verhalten 
+aber steht und fällt dann mit dem Zusammenhang 
+zwischen dem intendierten und 
+dem tatsächlichen Verhalten. Dieser Zusammenhang 
+ist aber aufgrund der vermuteten 
+starken Wirkung situativer1 Umstände 
+nicht zu erwarten. Außerdem überlegt die 
+Autorin, ob „das Teilnahmeverhalten …
+für Studierende habituell abläuft … als 
+Gewohnheit anzusehen [ist, so dass] das 
+Intentionsmaß irrelevant [wird]“ (S. 223).2 
+Zweitens zeigt ein Vergleich der bestehenden 
+Anwendungen des SEU Modells (Kapitel 
+D, §4.4) und des TOPB Modells (Kapitel 
+D, §5.3, Kap. F, §2.1) mit der Entscheidung, 
+an einer (kurzen) Onlineerhebung teilzunehmen, 
+dass letztere Entscheidung relativ 
+unbedeutend ist. Aus diesem Grund würde 
+man sich eine möglichst große Varianz der 
+modellierten befragten- und befragungsbezogenen 
+Einflussvariablen wünschen. Nun 
+ist die gewählte Stichprobe äußerst homogen.3 
+Mehr Varianz bei den Befragten hätte 
+etwa durch den Einbezug von mehr Universitäten, 
+mehr Nicht-Sozialwissenschaftlern, 
+oder auch Aufnahme von Nichtstudierenden 
+realisiert werden können. Beim Befra1 
+Befragungsthema, -dauer und Auftraggeber würde 
+ich nicht als situativ sondern als befragungsbezogen 
+betrachten.
+2 Diese Hypothese ließe sich anhand der Zeitspanne 
+zwischen Erhalt der E-Mail Aufforderung zur Teilnahme 
+und dem Zeitpunkt des Beginns der Befragung 
+testen. Bei den Teilnehmern, die die Befragung 
+spontan ausfüllen, sollte die Intention geringer sein 
+als bei denen, die sich länger Zeit lassen.
+3 Natürlich hat die gewählte Stichprobe den Vorteil 
+der kosten- und aufwandgünstigen Erhebung der 
+Probanden vor Ort sowie eine nahezu 100% Teilnahme 
+bei der Nullmessung.
+gungsdesign hätte eine tatsächliche Variation 
+von befragungsbezogenen Elementen 
+wie eine Randomisierung des Sponsors oder 
+des Befragungsthemas erfolgen können. 
+Natürlich setzt die geringe Stichprobengröße 
+hierbei enge Grenzen.4 Zudem wäre 
+eine – von der Autorin wegen unvollständigem 
+Rücklauf kritisierten – Nonresponse 
+follow-up bei nicht angegebenen E-Mail 
+Adressen möglich gewesen. Diese Kritiken 
+werden aber zum Teil bereits von der Autorin 
+problematisiert. 
+Eine vorsichtige Schlussfolgerung der 
+Ergebnisse könnte sein, dass insgesamt 
+nicht so sehr auf die (totale) Erklärungskraft 
+des tatsächlichen Teilnahmeverhaltens 
+durch die Variablen der beiden Modelle 
+fokussiert wird, sondern auf Einzelbefunde. 
+So könnte die Berücksichtigung der Tatsache, 
+dass Kostenkomponenten für verschiedene 
+Stichprobenmitglieder eine 
+unterschiedliche Wirkung haben können, 
+interessant sein. Zur besseren Erklärung 
+des Teilnahmeverhaltens könnte in Zukunft 
+mehr Gewicht auf das habitualisierte Verhalten 
+und situative Umstände gelegt werden. 
+Die Autorin zeigt, dass in Bezug auf das 
+habitualisierte Verhalten bei Teilnehmern 
+der ersten Welle bereits eine gewisse Verpflichtung 
+zur weiteren Teilnahme an der 
+zweiten Welle zu bestehen scheint, falls die 
+Teilnahme in der ersten Welle angenehm 
+verlief. Diese Erkenntnis kann zur Verbesserung 
+von Panelstudien ausgenutzt werden: 
+Möglicherweise sollte die erste Welle weniger 
+und angenehmere Fragen enthalten und 
+der Fragebogen in Folgewellen schrittweise 
+verlängert werden. Generell scheint die 
+Situation, in der sich Stichprobenmitglieder 
+zum konkreten Befragungszeitpunkt befinden, 
+eine weitaus bedeutendere Rolle für die 
+Teilnahmeentscheidung zu spielen als vorab 
+bekundete Teilnahmeintentionen. Für ein 
+4 Eine größere Analysestichprobe hätte man aber 
+eventuell erzielen können, wenn alle Probanden beide 
+Theorie-Komponenten beantwortet hätten.
+53 Rezensionen
+StepHan Büttner, 
+HanS-cHriStopH 
+HoBoHm, larS 
+müller (Hg.), 
+2011: Handbuch 
+Forschungsdaten-
+management. 
+Bock + Herchen 
+Verlag, Bad Honnef, 
+ISBN 978-3-88347-
+283-6, 24,90 EUR. 
+Online Version: 
+http://www.
+forschungsdaten-
+management.de/
+Man trifft immer wieder auf die teilweise 
+paradoxe Situation, dass die Vorteile und 
+Stärken wissenschaftlicher Methoden mit 
+nicht erbringbaren Leistungen legitimiert 
+werden oder dass zentrale Aspekte von Forschungsprozessen 
+kaum oder nur ungenügend 
+thematisiert werden, obwohl auf sie 
+beträchtliche Teile des wissenschaftlichen 
+Arbeitsprozesses entfallen. Beispielsweise 
+gehört es zum Kern des wissenschaftlichen 
+Selbstverständnisses, intersubjektiv zugängliche 
+und reproduzierbare Ergebnisse zu produzieren. 
+Aber ähnlich den Vergessenskurven 
+von Hermann Ebbinghaus gehen quer über 
+die verschiedenen Wissenschaftsfelder sehr 
+schnell die meisten relevanten Datenbestände 
+verloren. Wissenschaftliche Resultate 
+erweisen sich daher gerade nicht als intersubjektiv 
+zugänglich oder als reproduzierbar. 
+Ein anderer Punkt betrifft den Nutzen 
+wie den Vorteil von Sekundäranalysen sowie 
+das mit der Zeit wachsende Ergebnispotential 
+solcher Sekundäranalysen. Wegen der 
+vielfach unzugänglichen Daten wird auf 
+dieses Potential weitgehend verzichtet und 
+stattdessen auf jeweils neue Datenerhebungen 
+gesetzt, denen jeweils weitere neue 
+Datenerfassungen folgen. Die akkumulierten 
+Datenbestände aus der Vergangenheit, 
+obwohl sie aus kontextuellen oder aus langfristigen 
+Gesichtspunkten eine starke analytische 
+Bereicherung darstellen würden, 
+bleiben in ihrer überwiegenden Mehrzahl 
+besseres Verständnis sollten bei zukünftigen 
+Befragungen diese situativen Umstände 
+(Zeitpunkt, Haushaltskontexte, Stimmung, 
+Wetter, etc.) tatsächlich erhoben werden. 
+Diese Arbeit zeigt, dass für die Erforschung 
+von Nonresponse und Attrition noch ein 
+erhebliches Nachholpotential besteht. 
+Einige äußerst interessante Anregungen 
+werden von der Autorin am Beispiel einer 
+Onlineerhebung von Studierenden gegeben. 
+Es wäre zu begrüßen, wenn diese Anregungen 
+in weiterführenden Arbeiten aufgenommen 
+würden.
+ 

--- a/src/test/resources/bibExtractor/gold/35916.txt
+++ b/src/test/resources/bibExtractor/gold/35916.txt
@@ -1,0 +1,253 @@
+www.ssoar.info
+Empirische Forschungen an sozial- und
+politikwissenschaftlichen Lehrstühlen in
+Deutschland, der Schweiz und Österreich 2008 bis
+2011
+Hackenbroch, Rolf
+Veröffentlichungsversion / Published Version
+Zeitschriftenartikel / journal article
+Zur Verfügung gestellt in Kooperation mit / provided in cooperation with:
+GESIS - Leibniz-Institut für Sozialwissenschaften
+Empfohlene Zitierung / Suggested Citation:
+Hackenbroch, Rolf: Empirische Forschungen an sozial- und politikwissenschaftlichen Lehrstühlen in Deutschland, der
+Schweiz und Österreich 2008 bis 2011. In: Methoden, Daten, Analysen (mda) 7 (2013), 1, pp. 123-128. URN: http://
+dx.doi.org/10.12758/mda.2013.005
+Nutzungsbedingungen:
+Dieser Text wird unter einer CC BY Lizenz (Namensnennung) zur
+Verfügung gestellt. Nähere Auskünfte zu den CC-Lizenzen finden
+Sie hier:
+http://creativecommons.org/licenses/
+Terms of use:
+This document is made available under a CC BY Licence
+(Attribution). For more Information see:
+http://creativecommons.org/licenses/
+DOI: 10.12758/mda.2013.005methoden, daten, analysen · Jg. 7(1), S. 123-128
+Rolf Hackenbroch
+Empirische Forschungen 
+an sozial- und 
+politikwissenschaft-
+lichen Lehrstühlen 
+in Deutschland, der 
+Schweiz und Österreich 
+2008 bis 2011
+Empirical Research at 
+Social and Political 
+Science Departments 
+in Germany, Austria 
+and Switzerland from 
+2008 to 2011
+Zusammenfassung
+Die vorliegende Studie gibt einen Überblick 
+über die in empirischen Forschungsprojekten 
+an sozial- und politikwissenschaftlichen 
+Lehrstühlen in den Jahren 2008 bis 2011 
+angewandten Methoden und deren Finanzierungsform. 
+Anhand der Befragung von 
+41 Universitätsprofessoren wird aufgewiesen, 
+dass Einstellungs- und Umfrageforschung 
+– und hier vor allem repräsentative 
+Bevölkerungsbefragungen – den weitaus 
+größten Anteil der Forschungsprojekte stellen. 
+Deren Finanzierung – dies im Unterschied 
+zu nicht umfragebasierten Methoden 
+– erfolgt vorwiegend über Drittmittel und 
+die Durchführung wird zum überwiegenden 
+Teil von externen Markforschungsinstituten 
+vorgenommen. Wie sich die Bedeutung 
+von externen Instituten in der universitären 
+Forschungslandschaft in Zukunft gestaltet, 
+bleibt abzuwarten, wird doch die methodische 
+Entwicklung in der empirischen Sozialforschung 
+stark im Bereich der OnlineForschung 
+gesehen. 
+Abstract
+The present study provides an overview of 
+the methods and the type of financing used 
+in empirical research projects at social and 
+political science departments in the years 
+2008 to 2011. Based on a survey of 41 chairs 
+it can be shown that survey research - and 
+especially representative surveys – provides 
+the largest share of the research projects. 
+Their funding - this in contrast to non-sur-veybased 
+methods - primarily uses thirdparty 
+funding and their implementation is 
+done for the most part by external market 
+research institutions. How the importance 
+of such external institutions in the university 
+research environment develops in the 
+future remains to be seen, but the methodological 
+development in empirical social 
+research is greatly seen in the field of online 
+research.
+© The Author(s) 2013. This is an Open Access article distributed under the terms of the 
+Creative Commons Attribution 3.0 License. Any further distribution of this work must 
+maintain attribution to the author(s) and the title of the work, journal citation and DOI.
+methoden, daten, analysen · Jg. 7(1), S. 123-128124 
+1 Ausgangspunkt und Zielsetzung1
+Von März bis Oktober 2011 führte die teleResearch GmbH aus Mannheim eine 
+Erhebung zu Umfang, Finanzierung und Methodik empirischer Forschungsprojekte 
+an sozial- und politikwissenschaftlichen Lehrstühlen durch. Die Untersuchung 
+bezog sich auf Deutschland, Österreich und die Schweiz und hatte alle empirischen 
+Primärerhebungen, die im Rahmen eines wissenschaftlichen Forschungsprojektes 
+zwischen 2008 und 2011 durchgeführt wurden, zum Gegenstand. Erhebungen im 
+Rahmen von Lehrveranstaltungen oder anderweitigen Projekten, die nicht in einen 
+Forschungsbericht oder eine wissenschaftliche Publikation mündeten, waren nicht 
+Gegenstand der Befragung. 
+Die Studie gibt einen Überblick über die in der universitären Forschung 
+angewandten Methoden und Ansätze. Sie untersucht, welche Bedeutung Bevölkerungsumfragen 
+im Vergleich zu Befragungen von Entscheidern in der Wirtschaft 
+und der öffentlichen Verwaltung haben und ob es in Abhängigkeit von den Methoden 
+verschiedene Finanzierungsformen und unterschiedliche Beteiligungen externer 
+Meinungsforschungsinstitute gibt. Darüber hinaus werden die methodischen 
+Schwerpunkte zukünftiger sozial- und politikwissenschaftlicher Forschungen aus 
+Sicht der befragten Lehrstuhlinhaber dargestellt. 
+2 Methodik der Studie
+Die Ausgangsstichprobe der Befragung bildeten 174 Adressen von Lehrstühlen 
+für Sozialwissenschaften und Politikwissenschaften an deutschsprachigen 
+Universitäten. Diese Adressen wurden in einem ersten Schritt danach 
+qualifiziert, ob die jeweiligen Lehrstühle generell im Bereich empirischer Sozialforschung 
+tätig sind. Es verblieben 93 Adressen, die das Ausgangssample für die 
+vorliegende Erhebung darstellten. Von diesen Adressen verblieben nach Kontaktaufnahme 
+und Qualifizierung der Zielperson 75 befragungsrelevante, verwertbare 
+Adressen (= Grundgesamtheit). Von diesen konnten insgesamt 41 Universitätsprofessoren 
+über ein ca. 12-15 minütiges telefonisches Interview zum 
+Forschungsgegenstand befragt werden. Mit einer Quote von 55% haben wir in 
+dieser schwer zu erreichenden Zielgruppe eine sehr gute Ausschöpfung erreicht.
+1 Unser Dank für entscheidende Impulse bei der Durchführung der Befragung und der 
+Fertigstellung der Auswertung gilt Herrn Gazmend Dika und Herrn Jens Schumm.
+125 Hackenbroch: Empirische Forschungen ... 
+Abbildung 1 Ausschöpfungsübersicht
+Ausgangsstichprobe (= Adressen insgesamt) n=174
+Ausgangssample Interviews (= verwendete Adressen von Lehrstühlen in D, A, CH n=93 100%
+Davon nicht zur Grundgesamtheit gehörend: n=18 19%
+  falsche Zielgruppe n=7
+  Befragungskriterien nicht erfüllt (keine wissenschaftlichen Forschungsprojekte 
+in den letzten drei Jahren) 
+n=13
+Grundgesamtheit (= abgeschlossene, verwertbare Adressen) n=75 100%
+Davon Ausfälle gesamt: n=34 45%
+  verweigert / kein Interesse / keine Zeit n=14
+  trotz bis zu 20-facher Kontaktversuche niemand erreichbar n=20
+Realisierte Interviews n=41 55%
+* z.B. ZP an Uni nicht aufgeführt; falsches Institut; Hauptarbeitsplatz nicht am Lehrstuhl
+3 Ergebnisse der Untersuchung
+3.1 Art der Primärerhebungen an sozial-/ politikwissenschaftlichen 
+ Lehrstühlen 2008-2011 
+Fast alle Lehrstühle, die empirische Primärerhebungen in den Jahren 2008 bis 2011 
+durchführten, haben Einstellungs- und Umfragedaten erhoben (36 von 41). Bei 
+zwei Dritteln dieser Lehrstühle wurden repräsentative Bevölkerungsbefragungen 
+und bei ca. 40% spezifische Zielgruppen der Bevölkerung befragt. Auffallend ist 
+insgesamt, dass Befragungen zu Zielgruppen in Wirtschaft und öffentlicher Verwaltung 
+nur bei 4 der befragten 41 Lehrstühle stattfanden. Der Schwerpunkt der 
+Erhebung von Einstellungs- und Umfragedaten liegt so eindeutig bei Bevölkerungsbefragungen 
+und nicht in der Analyse von Entscheidern in Wirtschaft und 
+öffentlicher Verwaltung. 
+Rund die Hälfte der befragten Universitätsprofessoren gab an, jenseits 
+von Einstellungs- und Umfragedaten auch empirische Forschungsprojekte mittels 
+anderer Methoden durchzuführen. Dabei wurde die Inhaltsanalyse als Erhebungsmethode 
+vor Gruppendiskussion und Experiment (Feld-, Laborexperiment) 
+genannt. Schaut man sich die absolute Anzahl der Studien an, so fällt die Vorrangstellung 
+von Einstellungs- und Umfragedaten (insgesamt 149 Studien) vor anderen 
+methodischen Ansätzen (56 Studien) sehr deutlich aus. 
+methoden, daten, analysen · Jg. 7(1), S. 123-128126 
+Besonders interessant ist, dass im Bereich von Einstellungs- und Umfragedaten 
+telefonische, Online-, persönliche und auch schriftliche Befragungen 
+gleichhäufig vertreten sind. Dominieren im Bereich der außeruniversitären Forschung 
+eindeutig telefonische und Online-Befragungen, so spielen im universitären 
+Bereich persönliche und schriftliche Befragungen eine große Rolle. 
+3.2 Finanzierung und Durchführung
+Finanziert werden die Primärerhebungen von Einstellungs- und Umfragedaten 
+größtenteils über Drittmittel von Forschungsförderungsinstitutionen (vier Fünftel 
+aller Lehrstühle), nur ein geringerer Teil wird ausschließlich oder zusätzlich aus 
+Eigenmitteln des Lehrstuhls/ des Instituts/ der Universität bzw. Drittmitteln anderer 
+Auftraggeber gefördert.
+Anders sieht das Bild bei der Finanzierung solcher Untersuchungen aus, 
+die mittels Inhaltsanalyse, Gruppendiskussionen oder Experimenten durchgeführt 
+werden. Diese erfolgt bei etwa der Hälfte der Lehrstühle über den eigenen Lehrstuhl/ 
+Institut/ Universität und nur etwa zu 50% über Drittmittel von Forschungsförderungsinstitutionen 
+bzw. Drittmittel anderer Auftraggeber. Die Finanzierung 
+über eigene Mittel spielt also vor allem bei diesen Methoden eine herausragende 
+Rolle; Einstellungs- und Umfragedaten werden hingegen schwerpunktmäßig über 
+die Finanzierung durch Drittmittel von Forschungsförderungsinstitutionen sichergestellt. 
+
+3.3 Einsatz externer Marktforschungsinstitute
+Eine der zentralen Fragen der vorliegenden Untersuchung war, in welchem Ausmaß 
+externe Marktforschungsinstitute mit Primärerhebungen seitens der Lehrstühle 
+betraut werden. Das Ergebnis ist überraschend eindeutig: Externe Marktforschungsinstitute 
+werden fast ausschließlich bei der Erhebung von Einstellungs- und 
+Umfragedaten beauftragt (23 von 36 Lehrstühlen beauftragten – teilweise neben 
+der Erhebung über den eigenen Lehrstuhl – externe Institute), bei anderen Methoden 
+wie Inhaltsanalyse, Experteninterviews und Gruppendiskussionen werden nur 
+äußerst selten externe Institute beauftragt (3 von 22 Lehrstühlen). Als Gründe 
+für die Beauftragung externer Markt- und Meinungsforschungsinstitute wird vor 
+allem auf den Arbeitsaufwand und auf ökonomische Gründe verwiesen. Ein Viertel 
+der befragten Lehrstühle nennen darüber hinaus die Kompetenz und Erfahrung 
+externer Institute als Grund für das Outsourcing.
+127 Hackenbroch: Empirische Forschungen ... 
+Die Motivation wiederum, Primärerhebungen am eigenen Lehrstuhl durchzuführen, 
+liegt neben niedrigeren Kosten vor allem darin, dass Erhebungen am 
+Lehrstuhl eine bessere Kontrolle der Erhebungen und eine bessere Handhabung der 
+Gesamtstudie gewährleisten. Besonders bei Primärerhebungen über Inhaltsanalysen, 
+Gruppendiskussionen und Experimente ist dies mit Abstand das am häufigsten 
+genannte Argument. 
+Und nach welchen Kriterien fiel nun die Entscheidung für ein bestimmtes 
+externes Marktforschungsinstitut? Hier steht die Reputation und Qualität des 
+Instituts eindeutig an erster Stelle, gefolgt von Kostengründen und guten Erfahrungen. 
+Dabei sind die Lehrstühle mit den Leistungen der Markt- bzw. Meinungsforschungsinstitute 
+im Durchschnitt durchaus zufrieden (Mittelwert 2,1 auf einer 
+Skala von 1 = sehr zufrieden bis 5 = überhaupt nicht zufrieden). Zur Zufriedenheit 
+trug sowohl die Umsetzung der Studienanforderungen als auch die gute Zusammenarbeit 
+bei. Kritik an den Leistungen der externen Institute wurde jedoch von 
+rund der Hälfte der Lehrstühle formuliert. Diese bezog sich auf die Kommunikation, 
+die Umsetzung der Methodik und auf die Ergebnisse an sich. 
+Im Vergleich zu den Erhebungen mit externen Instituten fällt die Zufriedenheit 
+mit Erhebungen am eigenen Lehrstuhl bzw. der Universität jedoch deutlich 
+höher aus (Mittelwert 1,5 bei Umfragedaten - 21 Lehrstühle; Mittelwert andere 
+Methoden 1,6 – 18 Lehrstühle). Die geäußerte Zufriedenheit bezog sich hier vor 
+allem auf die Ergebnisse selbst, aber auch auf die Kontrolle des Erhebungsprozesses 
+und den Ablauf der Studie. Jedoch auch etwa die Hälfte der Lehrstühle äußerte 
+Unzufriedenheit mit Erhebungen am eigenem Lehrstuhl bzw. der Universität. Diese 
+bezog sich auf die Methodik und die Ergebnisse, aber auch auf die Qualität der 
+Durchführung. 
+Wenn auch die Zufriedenheit mit den Erhebungen am eigenen Lehrstuhl 
+– vor allem auf Grund der besseren Kontrolle über den Ablauf und den Prozess – 
+größer ist, so zeigt sich doch auch hier, dass durchaus Mängel festgestellt wurden. 
+Trotzdem: Es erweist sich, dass bei der Forschungszusammenarbeit vor allem 
+eine engere Verzahnung zwischen den Vorgaben und Vorstellungen der Lehrstühle 
+und der Erhebung der Markt- und Meinungsforschungsinstitute notwendig ist. 
+4 Methodische Schwerpunkte zukünftiger Forschung
+„Wo liegt in der empirischen Sozialforschung in Zukunft der Schwerpunkt bei der 
+Anwendung der Methoden?“ Fast die Hälfte (18 Lehrstühle) nennen auf diese offen 
+gestellte Frage die Online-Forschung als eindeutigen Schwerpunkt. Dazu gehören 
+methoden, daten, analysen · Jg. 7(1), S. 123-128128 
+Online-Panels, webbasierte Befragungen oder einfach nur Online-Befragungen. 
+Weitere sechs Lehrstühle nennen die Kombination verschiedener Befragungs- und 
+Forschungsmethoden als zukünftigen Schwerpunkt der Methodenausrichtung und 
+weitere fünf Lehrstühle Panelstudien. Darüber hinaus gibt es noch eine Vielzahl an 
+Einzelnennungen, jedoch neben den genannten Punkten keine dezidierten weiteren 
+Schwerpunkte.
+Das Resümee hieraus: Online-Forschung ist auch in der universitären Forschung 
+als Methode bereits fest etabliert. Wie jedoch weiter oben gezeigt wurde, 
+ist die derzeitige Situation bei Primärerhebungen in der wissenschaftlichen Forschung 
+ganz stark durch das gleichzeitige Auftreten von schriftlichen, telefonischen, 
+persönlich-mündlichen und Online-Befragungen gekennzeichnet. Dies 
+findet seine Begründung nicht zuletzt darin, dass es sich bei einem Großteil der 
+Studien um repräsentative Bevölkerungsbefragungen handelt. 
+Insofern ist es interessant zu sehen, dass der übergroße Teil (34 Lehrstühle) 
+repräsentativen Bevölkerungsumfragen in Zukunft eine gleichbleibende oder sogar 
+noch zunehmende Rolle zuspricht. Begründet wird dies mit der gesellschaftlichen 
+Relevanz dieser Art von Querschnittserhebungen. Nur eine Minderheit von fünf 
+Lehrstuhlinhabern geht hingegen von einer in Zukunft sinkenden Bedeutung aus. 
+Deren Begründung liegt im zunehmenden Nonresponse-Problem und der damit 
+verbundenen erschwerten Durchführbarkeit solcher Studien. 
+Trotz der starken Stellung, die der Online-Forschung perspektivisch zugeschrieben 
+wird, werden repräsentative Bevölkerungsbefragungen - ob telefonisch, 
+schriftlich oder face-to-face – weiterhin ihre starke Bedeutung behalten. Wie sich 
+deren Stellenwert genau entwickelt, wird spannend bleiben zu beobachten. 
+ 
+Anschrift des Autors Rolf Hackenbroch
+ teleResearch GmbH 
+ D6, 5
+ 68159 Mannheim
+ E-Mail: hackenbroch@teleresearch.de 

--- a/src/test/resources/bibExtractor/gold/37417.txt
+++ b/src/test/resources/bibExtractor/gold/37417.txt
@@ -1,0 +1,900 @@
+Diese Version ist zitierbar unter / This version is citable under:
+http://nbn-resolving.de/urn:nbn:de:0168-ssoar-374171
+www.ssoar.info
+BEFKI GC-K: eine Kurzskala zur Messung
+kristalliner Intelligenz
+Schipolowski, Stefan; Wilhelm, Oliver; Schroeders, Ulrich; Kovaleva,
+Anastassiya; Kemper, Christoph J.; Rammstedt, Beatrice
+Veröffentlichungsversion / Published Version
+Zur Verfügung gestellt in Kooperation mit / provided in cooperation with:
+GESIS - Leibniz-Institut für Sozialwissenschaften
+Empfohlene Zitierung / Suggested Citation:
+Schipolowski, Stefan ; Wilhelm, Oliver ; Schroeders, Ulrich ; Kovaleva, Anastassiya ; Kemper, Christoph J. ;
+Rammstedt, Beatrice: BEFKI GC-K: eine Kurzskala zur Messung kristalliner Intelligenz. In: Methoden, Daten, Analysen
+(mda) 7 (2013), 2, pp. 153-181. DOI: http://dx.doi.org/10.12758/mda.2013.010
+Nutzungsbedingungen:
+Dieser Text wird unter einer CC BY Lizenz (Namensnennung) zur
+Verfügung gestellt. Nähere Auskünfte zu den CC-Lizenzen finden
+Sie hier:
+http://creativecommons.org/licenses/
+Terms of use:
+This document is made available under a CC BY Licence
+(Attribution). For more Information see:
+http://creativecommons.org/licenses/
+DOI: 10.12758/mda.2013.010methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181
+Stefan Schipolowski, Oliver Wilhelm, Ulrich Schroeders, 
+Anastassiya Kovaleva, Christoph J. Kemper und 
+Beatrice Rammstedt
+BEFKI GC-K BEFKI GC-K 
+Zusammenfassung
+In aktuellen Intelligenzstrukturmodellen 
+gehört kristalline Intelligenz (gc) zu den 
+am besten etablierten Fähigkeitsfaktoren. 
+Dabei spiegelt gc die Einflüsse von Lernen 
+und Akkulturation wider und umfasst somit 
+alles Wissen, das Menschen im Laufe ihres 
+Lebens erwerben und zum Problemlösen 
+einsetzen. In diesem Beitrag beschreiben wir 
+die Entwicklung einer Kurzskala zur Messung 
+kristalliner Intelligenz mit fünfminütiger 
+Bearbeitungszeit, die auf deklarativen 
+Wissensfragen aus den Natur-, Geistes- und 
+Sozialwissenschaften beruht. Aus einem 
+umfangreichen Itempool wurde ein 32 Fragen 
+umfassender Wissenstest zusammengestellt 
+und einer bundesweit repräsentativen 
+Stichprobe von 1.134 Erwachsenen vorgelegt. 
+Anhand psychometrischer Kennwerte 
+und der Beziehungen zu Kovariaten erfolgte 
+eine Auswahl von 12 Items für die Kurzskala. 
+Ein eindimensionales Messmodell für diese 
+Itemauswahl wies eine gute Passung und 
+eine hohe Reliabilität des latenten Faktors 
+auf. In der Zielpopulation der erwachsenen 
+deutschen Bevölkerung wurden keine 
+substanziellen Boden- oder Deckeneffekte 
+Abstract
+Crystallized intelligence (gc) is a well-established 
+cognitive ability factor that has been 
+conceptualized as reflecting influences of 
+learning, education, and acculturation. In 
+this article, we describe the development 
+of a short knowledge scale for the measurement 
+of gc in five minutes administration 
+time using declarative knowledge 
+items from the sciences, the humanities, 
+and civics. Based on a large item pool we 
+compiled a 32-item knowledge test that 
+was subsequently presented to a nationally 
+representative sample of 1,134 German 
+adults. In the next step, this data were used 
+to derive a short 12-item knowledge scale. 
+A unidimensional measurement model had 
+satisfactory model fit and showed high reliability 
+of the latent factor. There were no 
+substantial floor or ceiling effects in the 
+adult German population. Similar to the 
+full scale, the short scale correlated highly 
+positively with education (ISCED-97) and 
+socio-economic status (ISEI) and was meaningfully 
+related to self-reported knowledge 
+and the Big Five personality traits. Therefore, 
+the short knowledge scale allows for 
+A Short Scale for the 
+Measurement of Crystallized 
+Intelligence
+Eine Kurzskala zur Messung 
+kristalliner Intelligenz
+© The Author(s) 2013. This is an Open Access article distributed under the terms of the 
+Creative Commons Attribution 3.0 License. Any further distribution of this work must 
+maintain attribution to the author(s) and the title of the work, journal citation and DOI.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181154 
+1 Einleitung1
+Die Messung psychologischer Merkmale wie kognitiver Fähigkeiten und Persönlichkeitseigenschaften 
+gewinnt in den Sozial- und Wirtschaftswissenschaften zunehmend 
+an Bedeutung (Rat für Sozial- und Wirtschaftsdaten 2010). So verweisen 
+etwa Grabner und Stern (2010) auf das komplexe, bisher jedoch nicht hinreichend 
+erforschte Zusammenspiel zwischen individuellen kognitiven Ressourcen und 
+sozioökonomischen Variablen. Auf Personenseite kommt hier neben der dekontextualisierten 
+Fähigkeit zum schlussfolgernden Denken bzw. dem Arbeitsgedächtnis 
+insbesondere jenen Fähigkeiten eine zentrale Rolle zu, die auf Lernen, Erfahrung 
+und Wissen beruhen und unter dem Begriff der kristallinen Intelligenz zusammengefasst 
+werden. Wiederholt wurde jedoch darauf hingewiesen, dass bislang nur 
+wenige für die Umfrageforschung geeignete, d.h. hinreichend kurze und effiziente 
+Messinstrumente zur Erfassung psychologischer Merkmale vorliegen (Rammstedt/
+Kemper/Klein/Beierlein/Kovaleva 2012; Lang/Weiss/Stocker/von Rosenbladt 2007).
+Der vorliegende Beitrag beschreibt die Entwicklung und Eigenschaften einer 
+Kurzskala zur Erfassung kristalliner Intelligenz anhand deklarativer Wissensfragen 
+in fünf Minuten Bearbeitungszeit. Die Datenbasis hierfür ist eine für die erwachsene 
+Wohnbevölkerung Deutschlands repräsentative Stichprobe, die dementsprechend 
+eine hohe Heterogenität bzgl. Alter und Bildung aufweist. Zuerst wird unter Rückgriff 
+auf einflussreiche Intelligenztheorien das Konstrukt der kristallinen Intelligenz 
+näher erläutert. Mit Blick auf die Validierung der Kurzskala folgt eine Darstellung 
+zentraler Befunde zu den Beziehungen zwischen kristalliner Intelligenz, relevanten 
+Personen- und Umweltmerkmalen sowie anderen psychologischen Konstrukten.
+1 Während der Erstellung dieses Beitrags war Stefan Schipolowski Fellow der International 
+Max Planck Research School „The Life Course: Evolutionary and Ontogenetic 
+Dynamics (LIFE)“.
+beobachtet. Übereinstimmend mit der 
+Langversion zeigten sich für die Kurzskala 
+hohe Beziehungen zum Bildungsabschluss 
+(ISCED-97) und sozioökonomischen Status 
+(ISEI) sowie erwartungskonforme Korrelationen 
+mit selbstberichtetem Wissen und den 
+fünf Hauptdimensionen der Persönlichkeit 
+(Big Five). Die Kurzskala ermöglicht folglich 
+eine effiziente, reliable und valide Erfassung 
+kristalliner Intelligenz im Rahmen der 
+Umfrageforschung.
+an efficient and valid measurement of crystallized 
+intelligence in survey research.
+155 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+1.1 Kristalline Intelligenz in konsensualen 
+Intelligenzstrukturtheorien
+Wissen und sprachliche Fähigkeiten spielen seit Beginn der psychometrischen 
+Intelligenzforschung im späten 19. Jahrhundert eine bedeutende Rolle in Intelligenztheorien. 
+So schlug Hermann Ebbinghaus bereits 1897 ein Verfahren zur „Prüfung 
+geistiger Fähigkeiten“ bei Schulkindern vor, das darauf beruhte, in kurzen 
+Texten unvollständige Wörter sinnhaft zu vervollständigen und charakterisierte 
+diese Anforderung explizit als „Intelligenzthätigkeit“ (Ebbinghaus 1897: 414). Für 
+Charles Spearman (1938) hingegen stellte non-verbales schlussfolgerndes Denken 
+den eigentlichen Kern allgemeiner Intelligenz, des sog. g-Faktors, dar. Nach Binet 
+und Simon (1905) sowie Hebb (1942) gehörte Cattell (1943) zu den ersten Intelligenzforschern, 
+die diese beiden Intelligenzaspekte aufgriffen und gegenüberstellten. 
+Statt eines einzigen Generalfaktors der Intelligenz postulierte Cattell zwei 
+bedeutende Faktoren, die er als fluide Intelligenz (gf) und kristalline Intelligenz (gc) 
+bezeichnete. Letztere zeigt sich nach Cattell (1971) in Leistungen, bei denen zuvor 
+erlernte Fertigkeiten und Wissen die entscheidende Rolle spielen. Typische Indikatoren 
+für gc bezeichnet Cattell als „schulische“ oder „akademische“ Tests, die auf 
+die Inhalte formaler Bildung abzielen. Damit übereinstimmend wurden in den Studien 
+in Cattells Labor (Cattell 1963; Horn/Cattell 1966; Cattell 1971) starke Ladungen 
+von sprachnahen Aufgaben und Wissenstests auf dem Faktor gc berichtet (vgl. 
+etwa Horn 1965). Aus Cattells theoretischen Schriften geht hervor, dass gc die 
+Gesamtheit des Wissens umfasst, das Menschen im Laufe ihres Lebens erwerben 
+und zum Problemlösen einsetzen. Aufgrund der mit steigendem Lebensalter zunehmenden 
+Spezialisierung in Form unterschiedlicher Berufswahlen, verschiedenartiger 
+Freizeitaktivitäten und Interessen würde eine umfassende Messung kristalliner 
+Intelligenz im Erwachsenenalter demnach eine nahezu unendliche Vielfalt an 
+Iteminhalten erfordern. Übereinstimmend betont auch Horn (1988) die Breite des 
+gc-Konstrukts und seine Nähe zum Generalfaktor der Intelligenz. In seiner Auflistung 
+typischer Indikatoren spielen verbale Fähigkeiten eine prominente Rolle (z.B. 
+„verbal knowledge“) sowie Wissen in einer Vielzahl von Bereichen („information 
+about the humanities, social and physical sciences, business and culture in general“; 
+Horn 1988: 659). Horn und Noll (1997: 69) beschreiben kristalline Intelligenz 
+dementsprechend als „akkulturiertes Wissen“, das über Aufgaben gemessen wird, 
+die „Tiefe und Breite des Wissens der dominanten Kultur“ widerspiegeln.
+Als weiteres einflussreiches Intelligenzmodell soll Carrolls (1993) Drei-Stra-tumTheorie 
+erwähnt werden, die nach wie vor als Status Quo der Intelligenzforschung 
+gilt. Das Modell basiert auf der Reanalyse von mehr als 460 Datensätzen zu 
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181156 
+kognitiven Fähigkeitskonstrukten und beschreibt verschiedene Schichten („Strata“) 
+mit Intelligenzfaktoren unterschiedlicher Breite. Zu den insgesamt acht Faktoren 
+auf Stratum II gehören auch gf und gc. Ähnlich wie Cattell betont auch Carroll mit 
+Blick auf den gc-Faktor die Rolle von Erfahrung, Lernen und Akkulturation, verschiebt 
+jedoch die Definition von gc in Richtung sprachlicher Fähigkeiten wie Leseverstehen 
+und Fremdsprachenkenntnissen (Carroll 1993: 626). Allerdings dokumentiert 
+Carroll auch die hohen Ladungen von Wissenstests auf dem gc-Faktor. Eine 
+besondere Bedeutung kommt dem Stratum-I-Faktor „General Information“ zu, der 
+Unterschiede im Erwerb von Wissen jenseits von Sprachkenntnissen widerspiegelt 
+(vgl. K0; Carroll 1993: 590 bzw. 634). Dieser Wissensfaktor gehört zu jenen Faktoren, 
+die in Carrolls Reanalysen häufig die höchste oder zweithöchste Ladung auf 
+einem übergeordneten gc-Faktor aufwiesen (vgl. auch Carroll 2003). In Übereinstimmung 
+mit den theoretischen Vorarbeiten Cattells untermauern diese Befunde 
+die Position, dass eine Operationalisierung kristalliner Intelligenz im Erwachsenenalter 
+Wissen aus möglichst vielen unterschiedlichen Bereichen berücksichtigen 
+sollte.
+1.2 Alters- und Geschlechtsunterschiede in kristalliner Intelligenz
+Das Konzept der kristallinen Intelligenz wurde auch von Seiten der Entwicklungspsychologie 
+über die Lebenspanne aufgegriffen (vgl. etwa Baltes 1987; Baltes/Staudinger/Lindenberger 
+1999), die wesentliche Erkenntnisse zum Entwicklungsverlauf 
+von gc liefern konnte. Nach Baltes et al. (1999: 486ff) zeigt die kristalline Pragmatik 
+der Kognition, die kulturell vermitteltes Wissen repräsentiert, einen deutlichen 
+Anstieg im Kindes- und Jugendalter, bleibt im Verlauf des Erwachsenenalters weitgehend 
+stabil und nimmt erst im sehr hohen Lebensalter ab. Auch Ackerman (2008) 
+argumentiert in seinem Literaturüberblick, dass sich gc im Sinne von Allgemeinwissen 
+und lexikalischem Wissen durch hohe Stabilität im Erwachsenenalter auszeichnet. 
+Ein anderes Bild ergibt sich jedoch für spezialisiertes, bereichsspezifisches 
+Wissen im Sinne von Expertise. So konnten Ackerman und Kollegen in mehreren 
+Studien zeigen, dass im Erwachsenenalter teilweise deutliche Leistungszuwächse 
+im bereichsspezifischen Wissen zu beobachten sind (Ackerman 2000; Ackerman/
+Rolfhus 1999; zusammenfassend Ackerman/Beier 2004). Diese Befunde illustrieren, 
+dass die Beziehung kristalliner Intelligenz zum Alter auch von den gemessenen 
+Inhalten abhängig ist. Wird gc über das im Kindes- und Jugendalter erworbene 
+schulische Wissen gemessen, das unabhängig vom Lebensalter häufig abgerufen 
+wird – wie es etwa für lexikalisches Wissen der Fall ist – sind kaum Veränderungen 
+im Erwachsenalter zu beobachten; wird gc hingegen als Expertise operationalisiert, 
+157 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+die erst durch eine spezielle Ausbildung oder durch die Berufsausübung erworben 
+wird, können auch im mittleren Erwachsenenalter substanzielle Zuwächse beobachtet 
+werden.
+Verschiedene Arbeiten aus der psychologischen Forschung haben sich mit 
+Geschlechtsunterschieden in Wissensleistungen auseinandergesetzt. Hier sind insbesondere 
+die Arbeiten von Lynn sowie aus der Arbeitsgruppe von Ackerman zu 
+erwähnen. In Untersuchungen an Jugendlichen bzw. jungen Erwachsenen mit einer 
+viele Wissensbereiche umfassenden Testbatterie wurde wiederholt ein Leistungsvorsprung 
+im Allgemeinwissen zugunsten der Männer von etwa einer halben Standardabweichung 
+gefunden (d = 0.50 bis 0.60; Lynn/Irwing/Cammock 2001; Lynn/
+Irwing 2002; Lynn/Wilberg/Margraf-Stiksrud 2004). Ähnliche Ergebnisse berichten 
+Ackerman, Bowen, Beier und Kanfer (2001), die eine Stichprobe von 320 Studierenden 
+mit einer breit angelegten Wissenstestbatterie zu 19 spezifischen Wissensbereichen 
+untersuchten. In 14 der 19 Wissensbereiche erzielten Männer signifikant 
+bessere Ergebnisse, insbesondere in den naturwissenschaftlich-technischen und 
+einigen sozialwissenschaftlichen Bereichen. Für keinen Wissensbereich ergaben 
+sich signifikant bessere Resultate für Frauen; in vier Bereichen fanden sich keine 
+oder sehr geringe Unterschiede. Insgesamt ergab sich für einen zusammengesetzten 
+Gesamtwert zum deklarativen Wissen ein Unterschied von d = 0.68 zugunsten 
+der Männer. Einschränkend muss jedoch gesagt werden, dass diese geschlechtsbezogenen 
+Disparitäten kulturspezifisch sind und nicht auf andere Kulturen übertragbar 
+sein müssen.
+1.3 Zusammenhänge kristalliner Intelligenz mit Bildung und 
+Lernumwelt
+Wie oben ausgeführt, ist die Abhängigkeit kristalliner Intelligenz von Lernen und 
+Bildung das zentrale Definitionsmerkmal des Konstrukts. Aufgrund der Langfristigkeit 
+des Wissenserwerbs und dessen Abhängigkeit von den zur Verfügung stehenden 
+Lerngelegenheiten und -ressourcen sind folglich hohe Zusammenhänge 
+zwischen gc und der Qualität und Quantität formaler Bildung zu erwarten, wie 
+sie in formalen Bildungsabschlüssen und darauf beruhenden Indizes zum Ausdruck 
+kommen (Cliffordson/Gustafsson 2008; Ceci 1991). Ebenso kann eine substanzielle 
+positive Korrelation mit solchen Indikatoren und Indizes angenommen werden, die 
+für den Wissenserwerb bedeutsame Ressourcen erfassen (Rowe/Jacobson/van den 
+Oord 1999). Dies betrifft Maße des sozioökonomischen Status ebenso wie Fragen 
+nach der Ausstattung des Haushalts, etwa zur Anzahl der verfügbaren Bücher 
+(Ehmke/Siegle 2005).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181158 
+1.4 Zusammenhänge kristalliner Intelligenz mit Selbsteinschätzungen 
+des Wissens und Persönlichkeitskonstrukten
+Neben einer Testung deklarativen Wissens über Wissensfragen mit mehreren Antwortalternativen, 
+die eindeutig als richtig oder falsch zu werten sind, können auch 
+Selbstberichte herangezogen werden. Derartige Selbsteinschätzungen des eigenen 
+Wissens spiegeln jedoch neben der tatsächlichen Fähigkeitsausprägung weitere 
+Varianzquellen wider (z.B. faking-good), so dass Selbsteinschätzungen des Wissens 
+und objektive Wissenstests als unterschiedliche, wenngleich korrelierte Konstrukte 
+aufzufassen sind (Furnham/Dissou 2007). Die Korrelationen zwischen entsprechenden 
+Messungen sind somit zwar substanziell, fallen aber selbst unter Verwendung 
+von Ansätzen zur Korrektur von Antwortverzerrungen deutlich niedriger aus als 
+zwischen Messungen desselben Konstrukts (Hülür/Wilhelm/Schipolowski 2011; 
+Rolfhus/Ackerman 1996; Paulhus/Harms 2004).
+Eine Vielzahl an Studien hat sich mit den Zusammenhängen zwischen kognitiven 
+Fähigkeiten einerseits und Persönlichkeitseigenschaften im Sinne typischen 
+Verhaltens (Cronbach 1949) andererseits befasst. Hervorzuheben ist die Metaanalyse 
+von Ackerman und Heggestad (1997), die anhand von 135 Studien die 
+Beziehungen zwischen Persönlichkeits- und Fähigkeitskonstrukten beleuchtet. Die 
+Autoren beschränken sich auf der Fähigkeitsseite nicht auf die Betrachtung allgemeiner 
+Intelligenz, sondern differenzieren zwischen zehn verschiedenen Fähigkeitskonstrukten, 
+darunter kristalline Intelligenz und eine zusammengefasste Kategorie 
+Wissen/Achievement. Bei der Kategorisierung der gemessenen Konstrukte 
+orientieren sich die Autoren an den Charakterisierungen der Fähigkeitsfaktoren bei 
+Carroll (1993). Kristalline Intelligenz umfasst demnach sprachliche Leistungen und 
+Allgemeinwissen (vgl. Carroll 1993: 599); zur Kategorie Wissen/Achievement zählen 
+neben spezifischen Wissenstests auch Fachleistungstests etwa im Schulfach Biologie 
+(vgl. Carroll 1993: 513). Die Persönlichkeitsskalen der Studien wurden anhand 
+verschiedener in der Forschung etablierter Systeme klassifiziert, darunter das 
+Modell der fünf Hauptdimensionen der Persönlichkeit (Big Five; für ausführliche 
+Beschreibungen dieser Dimensionen siehe Ostendorf/Angleitner 2004). Die metaanalytische 
+Betrachtung der korrelativen Zusammenhänge zwischen den Big FiveFaktoren 
+und gc bzw. Wissen/Achievement ergab jeweils die mit Abstand höchsten 
+Beziehungen für Offenheit. Hier wurde eine minderungskorrigierte Korrelation von 
+.30 (gc) bzw. .28 (Wissen/Achievement) ermittelt. Eine ebenfalls positive, aber mit 
+.11 deutlich niedrigere Korrelation zeigte sich zwischen gc und Extraversion. Für 
+Wissen/Achievement lag diese bei .05 und war nicht signifikant von null verschieden. 
+Negative Zusammenhänge wurden hingegen mit Neurotizismus (Korrelationen 
+159 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+von -.09 mit gc und -.13 mit Wissen/Achievement) und Gewissenhaftigkeit gefunden, 
+wobei die Korrelation zwischen Gewissenhaftigkeit und gc nicht signifikant 
+war und für Wissen/Achievement mit -.19 zwar vom Betrag her höher ausfiel, diese 
+Angabe jedoch nur auf einer einzigen Studie mit relativ geringer Fallzahl basiert. 
+Die Korrelationen mit Verträglichkeit waren nicht signifikant von null verschieden. 
+Die vergleichsweise hohe Beziehung zwischen gc bzw. Wissen/Achievement 
+und Offenheit ist sowohl empirisch gut belegt (von Stumm/Ackerman 2012) als 
+auch aus theoretischer Perspektive plausibel. So zielen Items zur Messung von 
+Offenheit unter anderem auf intellektuelle Neugier, das Bestreben, neues Wissen 
+zu erwerben und auf kulturelles Engagement (Ostendorf/Angleitner 2004). Folgerichtig 
+beschreibt Ackerman (1996) neben „typischem intellektuellem Engagement 
+(TIE)“ Offenheit als Persönlichkeitskonstrukt mit den höchsten Beziehungen zu gc 
+und geisteswissenschaftlichem Wissen. Übereinstimmend argumentieren Ziegler, 
+Danay, Heene, Asendorpf und Bühner (2012), dass Personen mit hohen Offenheitswerten 
+mehr Zeit in Lernen und Wissenserwerb investieren.
+1.5 Zusammenfassung und erwartete Zusammenhänge
+Aus theoretischen und diagnostischen Überlegungen heraus sollte eine Operationalisierung 
+von gc über deklaratives Wissen aus möglichst vielen verschiedenen 
+Wissensbereichen erfolgen. Zu erwarten sind hohe positive Korrelationen zwischen 
+kristalliner Intelligenz und der Qualität und Quantität formaler Bildung sowie mit 
+Indikatoren, die für den Wissenserwerb bedeutsame Ressourcen erfassen, wie beispielsweise 
+Maße des sozioökonomischen Status. Mit Blick auf Altersunterschiede 
+ist in der Erwachsenenpopulation aufgrund der hohen Stabilität kristalliner Intelligenz 
+von sehr geringen Effekten auszugehen, sofern die gemessenen Inhalte auf 
+solche Wissensbestände abzielen, die in einer Vielzahl von Lernumwelten erworben 
+werden können. In Anlehnung an die in der Literatur beschriebenen geschlechtsbezogenen 
+Unterschiede in Wissensleistungen wird ein Vorsprung der Männer von 
+etwa einer halben Standardabweichung bis zwei Drittel einer Standardabweichung 
+erwartet. Des Weiteren ist von positiven Korrelationen von gc mit selbsteingeschätztem 
+Wissen sowie mit dem Persönlichkeitsfaktor Offenheit auszugehen.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181160 
+2 Methode
+2.1 Stichprobe
+Als Grundgesamtheit für die Stichprobenziehung wurde die Wohnbevölkerung der 
+Bundesrepublik Deutschland im Alter von 18 Jahren und älter definiert. Es wurden 
+auch Personen mit Zuwanderungshintergrund berücksichtigt, sofern sie die 
+deutschsprachigen Fragen und Aufgaben verstehen und auf Deutsch antworten 
+konnten. Die Stichprobe wurde mithilfe des ADM-Stichprobensystems F2F der 
+Arbeitsgemeinschaft deutscher Marktforschungsinstitute gezogen. Dabei handelt 
+es sich um ein komplexes mehrstufiges Ziehungsverfahren, in dem zunächst Flächen, 
+dann Privathaushalte und schließlich Zielpersonen innerhalb der Haushalte 
+nach einem Zufallsverfahren ausgewählt werden (für Details vgl. von der Heyde 
+2009). Nach diesem Verfahren wurde eine Stichprobe von 1206 Personen realisiert, 
+die an der Erhebung teilnahmen. Im Anschluss wurden auf Basis des Zensus von 
+GESIS Fallgewichte erstellt, um Repräsentativität für die o.g. Grundgesamtheit mit 
+Blick auf Region (Ost- bzw. Westdeutschland), Geschlecht, Bildung und Alter zu 
+gewährleisten. Grundlage der Gewichtung war ein reduzierter Datensatz von 1.134 
+Fällen nach Ausschluss unbrauchbarer Datenpunkte sowie von Personen ohne 
+deutsche Staatsbürgerschaft, um für die Gewichtung eine eindeutige Definition 
+der Grundgesamtheit zu ermöglichen. Die gewichtete Stichprobe umfasst somit 
+1.134 Erwachsene (52,2% weiblich) im Alter von 18 bis 93 Jahren (M = 52 Jahre, 
+SD = 18 Jahre) aus dem gesamten Bundesgebiet.
+2.2 Messinstrumente
+In einem umfangreichen Fragebogen wurden verschiedene soziodemographische 
+Merkmale der Teilnehmerinnen und Teilnehmer erfasst. Hierzu zählten Geburtsjahr 
+und -monat, Geschlecht, Familienstand, Staatsangehörigkeit, erreichter bzw. 
+(bei Schülerinnen und Schülern) angestrebter allgemeinbildender Schulabschluss, 
+beruflicher Ausbildungsabschluss, Erwerbsstatus, berufliche Stellung und Haushaltsnettoeinkommen. 
+Die Erfassung dieser Merkmale orientierte sich an den 
+Demographischen Standards des Statistischen Bundesamtes (2010). Ergänzend 
+wurde anhand von sieben Kategorien die Anzahl der Bücher im Elternhaus erfragt, 
+das Geburtsland sowie die berufliche Stellung der Eltern, als der/die Teilnehmende 
+15 Jahre alt war. Anhand zweier fünfstufiger Skalen wurden vom Interviewer die 
+Deutschkenntnisse und die soziale Schichtzugehörigkeit der Teilnehmenden eingeschätzt.161 
+Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Zur Messung kristalliner Intelligenz wurde auf den umfangreichen Itempool 
+des BEFKI-Projekts (Berliner Test zur Erfassung Fluider und Kristalliner Intelligenz; 
+Wilhelm/Schroeders/Schipolowski, in Vorbereitung; Wilhelm/Schipolowski 
+2010) zurückgegriffen, mit dem deklaratives Wissen in 16 verschiedenen Domänen 
+erfasst werden kann. Im Einzelnen wird naturwissenschaftliches (Physik, Chemie, 
+Biologie, Medizin, Geografie, Technologie), geisteswissenschaftliches (Literatur, 
+Kunst, Musik, Religion, Philosophie) und sozialwissenschaftliches Wissen erfragt 
+(Geschichte, Recht, Politik, Wirtschaft, Finanzen). Die Auswahl der Wissensbereiche 
+orientierte sich an der empirisch begründeten Klassifikation von Ackerman (2000; 
+Rolfhus/Ackerman 1999). Für die aktuelle Studie wurden insgesamt 32 Wissensitems 
+anhand inhaltlicher und psychometrischer Kriterien aus dem Gesamtitempool 
+ausgewählt. Konkret wurden zwei Items aus jedem der 16 Wissensbereiche 
+eingesetzt, wobei eines der beiden Items zu jedem Bereich von geringer bis mittlerer 
+Schwierigkeit war (entwickelt für Personen ohne Schulabschluss, mit Haupt-schul 
+oder Mittlerem Schulabschluss), das andere von hoher Schwierigkeit (entwickelt 
+für Personen, die über die Hochschulreife verfügen bzw. diese anstreben). 
+Die psychometrische Eignung der Items wurde anhand von Vorinformationen aus 
+verschiedenen Erhebungen sichergestellt (Schipolowski/Schroeders/Wilhelm 2008; 
+Schroeders/Schipolowski/Wilhelm 2010; Schroeders/Schipolowski/Nelles/Wilhelm 
+2011). Ausschlaggebend war dabei neben den Informationen zur Itemschwierigkeit 
+insbesondere eine hohe positive Trennschärfe in den genannten Voruntersuchungen. 
+Alle Wissensitems waren ausschließlich textbasiert und hatten ein Multiple-ChoiceFormat 
+mit vier Antwortalternativen, von denen genau eine die richtige 
+Lösung darstellte.
+Zusätzlich zur kristallinen Intelligenz wurden weitere psychologische Konstrukte 
+erfasst. Der BFI-10 (Rammstedt/John 2007) ermöglichte die Erfassung der 
+Big-Five-Persönlichkeitsdimensionen Neurotizismus (N), Extraversion (E), Offenheit 
+(O), Verträglichkeit (V) und Gewissenhaftigkeit (G) anhand von jeweils zwei (N, E, O, 
+G) bzw. drei Items (V). Die Items bestanden aus Aussagen, deren Zutreffen von den 
+Teilnehmenden auf einer fünfstufigen Ratingskala eingeschätzt wurde. Mit dem 
+VOC-T (Ziegler/Kemper/Rammstedt 2013) wurde zudem ein Maß für die Selbsteinschätzung 
+des eigenen Wissens eingesetzt. Zu insgesamt 12 verschiedenen Begriffen 
+aus den Natur-, Geistes- und Sozialwissenschaften sowie dem handwerklichen 
+Bereich gaben die teilnehmenden Personen anhand einer siebenstufigen Ratingskala 
+an, wie vertraut sie mit dem jeweiligen Begriff oder Konzept sind. Neben diesen 
+real existierenden Begriffen enthält der VOC-T zusätzlich drei fiktive Begriffe.
+Weitere eingesetzte Skalen dienten der Erfassung von Lebenszufriedenheit, 
+politischer Partizipation, Werten, Kontrollüberzeugungen, Selbstwirksamkeitsermethoden, 
+daten, analysen · 2013, Jg. 7(2), S. 153-181162 
+wartungen, Impulsivität und dem Gesundheitszustand. Da diese Skalen nur in das 
+Imputations-, nicht jedoch in das Analysemodell einbezogen wurden, werden sie 
+hier nicht näher beschrieben.
+2.3 Durchführung
+Die Erhebung der Daten erfolgte im Zeitraum 2. Mai bis 23. Juni 2011 durch ein 
+beauftragtes Erhebungsinstitut. Geschulte Interviewer suchten die Studienteilnehmerinnen 
+und -teilnehmer zu vorab vereinbarten Terminen in ihren Wohnungen 
+auf, um die Befragung bzw. Testung durchzuführen. Die soziodemographischen 
+Angaben und die Antworten auf die Persönlichkeitsitems wurden vom Interviewer 
+erfragt und in eine Eingabemaske am Notebook eingegeben (CAPI, computer 
+assisted personal interview). Den gc-Test bearbeiteten die Teilnehmenden selbstständig 
+am Notebook (CASI, computer assisted self-interview). In beiden Fällen war 
+die Abfolge der Fragen durch ein Skript vorgegeben, um einen standardisierten 
+Ablauf zu gewährleisten. Beim gc-Test wurden immer vier Fragen gleichzeitig auf 
+dem Bildschirm dargestellt; um zur nächsten Bildschirmseite zu gelangen, musste 
+die teilnehmende Person zunächst alle vier Fragen der aktuellen Seite beantworten 
+(ggf. durch Raten). Für die Bearbeitung der 32 gc-Items war ein Zeitlimit von 10 
+Minuten vorgegeben. Bei Erreichen des Zeitlimits brach der Wissenstest automatisch 
+ab und es wurde mit dem nächsten Fragenkomplex fortgefahren. Die Dauer 
+des gesamten Interviews betrug im Durchschnitt 43 Minuten (SD = 13).
+2.4 Datenaufbereitung und Auswertungsverfahren
+Zur Aufbereitung der gewichteten Stichprobendaten wurden im ersten Schritt 
+anhand der vorliegenden demographischen Angaben verschiedene Indizes gebildet. 
+Als Index zur formalen Bildung wurde die ISCED-97 (International Standard Classification 
+of Education; UNESCO 1997) genutzt. Dabei wurden die Angaben zum 
+höchsten erreichten Schulabschluss sowie zum Ausbildungsabschluss in einer ordinalskalierten 
+Variable mit 6 Stufen zusammengeführt (vgl. Statistisches Bundesamt 
+2010: 79). Auf der niedrigsten Stufe (ISCED 1) befinden sich demnach Personen 
+ohne Schul- und Ausbildungsabschluss, während die höchste Stufe (ISCED 6) mit 
+Personen besetzt ist, die die allgemeine oder Fachhochschulreife besitzen und nach 
+erfolgreichem Hoch- bzw. Fachhochschulabschluss zusätzlich einen weiterführenden 
+akademischen Grad (Promotion) erlangt haben. Als Index des sozioökonomischen 
+Status wurde der ISEI (International Socio-Economic Index of Occupational 
+Status; Ganzeboom/De Graaf/Treiman 1992) verwendet. Der ISEI beruht auf Anga163 
+Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+ben zur Berufstätigkeit und der Prämisse, dass diese Informationswert bezüglich 
+Einkommen und Bildung besitzt, die wiederum „die Hauptquellen der Macht in 
+modernen Gesellschaften“ sind (Ganzeboom et al. 1992: 9). Konkret werden einzelnen 
+Berufen Statuswerte zugeordnet, die auf internationalen Daten zum Einkommen 
+und zur Bildung beruhen, über die Ausübende dieser Berufstätigkeiten typischerweise 
+verfügen. Auf dieser Basis ergibt sich eine Skala von 16 (niedriger Status; 
+etwa Reinigungskräfte) bis 90 (hoher Status; Richter). Ein Weg zur Ermittlung der 
+ISEI-Werte ist die Kodierung von Berufstätigkeiten nach der ISCO (International 
+Standard Classification of Occupations; ILO 2007). Im vorliegenden Fall wurde ein 
+weniger aufwändiges Vorgehen gewählt, das auf Angaben zur beruflichen Stellung 
+beruht, von der nach Wolf (1995) ebenfalls auf den ISEI geschlossen werden 
+kann (vgl. Statistisches Bundesamt 2010). Nach diesem Vorgehen ergibt sich für die 
+aktuelle Studie eine vereinfachte ISEI-Skala mit 13 verschiedenen Ausprägungen. 
+Die Bildung des ISEI wurde für die Teilnehmenden selbst sowie für deren Eltern 
+durchgeführt; in letzterem Fall wird für die folgenden Analysen der höchste der 
+beiden elterlichen ISEI-Werte (HISEI) verwendet. Das Haushaltsnettoeinkommen 
+wurde auch direkt erfragt, wobei zum Teil Freitextantworten, überwiegend jedoch 
+Angaben in Form von Einkommenskategorien vorlagen. Freitextanworten wurden 
+auf die vorliegenden 24 Kategorien rekodiert, um ein einheitliches Antwortformat 
+zu erhalten.
+Für die Skalen zu den psychologischen Konstrukten wurden Summen- oder 
+Mittelwerte so gebildet, wie dies von den Autoren der jeweiligen Instrumente vorgeschlagen 
+wurde. Somit lag für die folgenden Analysen jeweils ein Wert für jede 
+der fünf Big-Five-Dimensionen vor. Als Indikator des selbstberichteten Wissens 
+wurde ein Gesamtwert über alle 12 Items des VOC-T genutzt, die sich auf real existierende 
+Begriffe beziehen; die fiktiven Begriffe wurden nicht einbezogen2. 
+Die Items zur Messung der kristallinen Intelligenz wurden zunächst in richtig 
+versus falsch beantwortet rekodiert. Anschließend wurde ein Summenwert über 
+alle 32 Items als Schätzer der Personenfähigkeit auf der Gesamtskala berechnet. 
+Auf Basis der 32 Wissensitems der Gesamtskala erfolgte im nächsten Schritt die 
+Itemselektion für die Kurzskala nach folgenden Kriterien:
+  Um einen flexiblen Einsatz der Kurzskala in der Umfrageforschung zu ermöglichen, 
+sollte deren Bearbeitungszeit bei 5 Minuten liegen. Dies entspricht der 
+geschätzten Bearbeitungszeit von 12 Items.
+2 Die fiktiven Begriffe des VOC-T, engl. foils, können zur Berechnung weiterer Kennwerte 
+herangezogen werden, die jedoch im vorliegenden Beitrag nicht berücksichtigt werden.methoden, 
+daten, analysen · 2013, Jg. 7(2), S. 153-181164 
+  Zur bestmöglichen Erhaltung der inhaltlichen Breite der Wissensmessung sollte 
+einerseits die Dreiteilung in natur-, geistes- und sozialwissenschaftliches Wissen 
+beibehalten werden, andererseits sollten möglichst viele der 16 Wissensbereiche 
+der Gesamtskala auch in der Kurzskala enthalten sein.
+  Um Boden- und Deckeneffekte zu minimieren, sollten die ausgewählten Items 
+einen großen Schwierigkeitsbereich abdecken. Die relative Lösungshäufigkeit 
+sollte jedoch stets oberhalb der Ratewahrscheinlichkeit von .25 liegen.
+  Es wurde ein einfaktorielles Messmodell mit guter Modellpassung und Itemladungen 
+(Trennschärfen) von .50 oder höher angestrebt. In keinem Fall sollten 
+Ladungen < .30 auftreten.
+  Die Kurzskala sollte ähnliche Beziehungen zu Personen- und Umweltmerkmalen 
+sowie anderen psychologischen Konstrukten aufweisen wie die Gesamtskala.
+Nach erfolgter Itemselektion wurde für die Kurzskala mit 12 Items ebenfalls ein 
+Summenwert berechnet. 
+Um Einschränkungen bei der Teststärke sowie Verzerrungen durch nicht 
+zufällig fehlende Informationen3 zu minimieren, wurden fehlende Datenpunkte im 
+Wissenstest sowie in allen Kovariaten imputiert (Lüdtke/Robitzsch/Trautwein/Köller 
+2007). Der Anteil fehlender Werte bei den 32 Wissensitems betrug im Mittel pro 
+Item 5.8% (SD = 7.0%, Spannweite 0.4% bis 20.8%); die vorliegenden Fallzahlen 
+für die Kovariaten gehen aus der Ergebnistabelle hervor (vgl. Tabelle 4, Spalte Nvi). 
+Speziell bei den Wissensitems, für die Datenpunkte fast ausschließlich aufgrund der 
+Zeitbegrenzung fehlten, ermöglichte die Imputation eine Minimierung konstruktirrelevanter 
+Varianz (etwa interindividuelle Unterschiede in mentaler Geschwindigkeit; 
+Danthiir/Roberts/Schulze/Wilhelm 2004). Konkret wurde das Verfahren der 
+multiplen Imputation mit 100 Replikationen genutzt (Graham/Olchowski/Gilreath 
+2007). Um die fehlenden Werte möglichst zuverlässig schätzen zu können, wurden 
+alle verfügbaren Kovariaten, also Personen- und Umweltmerkmale sowie psychologische 
+Konstrukte, in das Imputationsmodell einbezogen (Collins/Schafer/Kam 
+2001). Die im Ergebnisteil berichteten Statistiken und Koeffizienten sind Mittelwerte 
+über alle Replikationen. Bei der Ermittlung von Standardfehlern wurde die 
+Streuung zwischen den Replikationen berücksichtigt.
+Zur Berechnung von Kovarianzen bzw. Korrelationen kamen Verfahren 
+zum Einsatz, die dem Skalenniveau der einbezogenen Variablen Rechnung tragen. 
+3 Als „nicht zufällig fehlende Informationen“ sind solche Ausfälle zu betrachten, die von 
+der Ausprägung der fraglichen Variable selbst und/oder anderen beobachteten Variablen 
+abhängig sind; vgl. die Definition von Missing Not At Random (MNAR) und Missing 
+At Random (MAR) bei Rubin (1976).
+165 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Entsprechend der kategorialen (dichotomen) Natur der rekodierten Wissensitems 
+wurden Messmodelle mittels konfirmatorischer Faktorenanalyse unter Verwendung 
+des WLSMV-Schätzers in Mplus 6.1 (Muthén/Muthén 1998-2010) berechnet. Zur 
+Beurteilung der Modellpassung wurden neben dem Chi-Quadrat-Wert und den 
+Freiheitsgraden weitere gebräuchliche Fitindizes wie CFI (Comparative fit index), 
+RMSEA (Root mean square error of approximation) und WRMR (Weighted root 
+mean square residual) herangezogen. Nach Yu (2002) zeichnen sich Modelle mit 
+kategorialen Daten und guter Passung durch folgende Werte aus: CFI ≥ .96, RMSEA 
+≤ .05 und WRMR ≤ .95. Alle Analysen erfolgten unter Verwendung der Fallgewichte.3 
+Ergebnisse
+3.1 Itemstatistiken
+Die Entwicklung der Kurzskala erfolgte auf Basis des vorliegenden Datensatzes 
+durch Itemselektion aus der 32 Items umfassenden Gesamtskala nach den oben 
+genannten Kriterien (vgl. Abschnitt 2.4). In Tabelle 1 sind die Schwierigkeiten, die 
+Itemladungen (äquivalent zu Trennschärfen in der klassischen Testtheorie) und die 
+Tabelle 1 Schwierigkeiten und Trennschärfen der Kurzskala-ItemsItemNr. 
+Itembezeichner Wissensbereich Wissensdomäne p λ
+1 med Medizin Naturw. .88 .58
+2 rel Religion Geistesw. .69 .67
+3 geo Geografie Naturw. .78 .58
+4 kun Kunst Geistesw. .44 .64
+5 bio Biologie Naturw. .33 .45
+6 pol Politik Sozialw. .62 .52
+7 phi Philosophie Geistesw. .40 .51
+8 phy Physik Naturw. .44 .35
+9 lit Literatur Geistesw. .51 .56
+10 fin Finanzen Sozialw. .77 .58
+11 rec Recht Sozialw. .64 .39
+12 ges Geschichte Sozialw. .55 .46
+Anmerkungen: Naturw.: Naturwissenschaften; Geistesw.: Geisteswissenschaften; Sozialw.: Sozialwissenschaften; 
+p: relative Lösungshäufigkeit; λ: Itemladung im einfaktoriellen Messmodell (vgl. Abbildung 1, Modell b).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181166 
+inhaltliche Zuordnung zu den drei breiten Wissensdomänen bzw. den einzelnen 
+Wissensbereichen für die ausgewählten Items angegeben. Werden die entsprechenden 
+Summenscores herangezogen, korreliert die Kurzskala mit der Gesamtskala 
+zu r = .91.
+3.2 Messmodelle und Reliabilität
+Im Folgenden werden zwei konkurrierende Messmodelle für die Kurzskala gegenübergestellt 
+und hinsichtlich ihrer Passung verglichen. Im dreifaktoriellen Modell 
+werden drei Faktoren gemäß der drei breiten Wissensdomänen Natur-, Geistes- 
+und Sozialwissenschaften spezifiziert. Auf jedem der drei Faktoren laden dabei 
+nur die Items aus der entsprechenden Domäne. Da kristalline Intelligenz als übergeordnetes 
+Fähigkeitskonstrukt Wissen aller Bereiche umfasst, ist von positiven 
+Korrelationen zwischen den drei domänenspezifischen Faktoren auszugehen. Das 
+einfaktorielle Messmodell repräsentiert kristalline Intelligenz hingegen mit einem 
+einzigen Faktor, auf dem alle 12 Items der Kurzskala laden. Eine weitere Untergliederung 
+in verschiedene Wissensdomänen wird nicht modelliert. Das einfaktorielle 
+Modell stellt somit einen Spezialfall des komplexeren dreifaktoriellen Modells dar, 
+weshalb zum Modellvergleich auch die Differenz der Chi-Quadrat-Werte formal 
+auf Signifikanz getestet werden kann (Schulze 2004). Die beiden Messmodelle sind 
+in Abbildung 1 dargestellt; die Passung der Modelle kann Tabelle 2 entnommen 
+werden.
+Das dreifaktorielle Modell (a) weist eine signifikant bessere Passung auf 
+(∆χ²(N = 1.134, 3) = 15.2, p = .002), was sich auch an den anderen in Tabelle 2 
+ausgewiesenen Fitindizes zeigt. Der Unterschied ist allerdings gering; auch für das 
+einfaktorielle Modell (b) ergibt sich eine zufriedenstellende Passung. Übereinstimmend 
+mit dem geringen Unterschied in der Modellpassung zeigen sich im dreifaktoriellen 
+Modell hohe messfehlerbereinigte Korrelationen zwischen den drei Wissensdomänen, 
+die zwischen .80 und .96 liegen.
+Für die folgenden Analysen wird das einfaktorielle Messmodell verwendet, 
+da es eine zufriedenstellende Passung aufweist, die nur geringfügig schlechter ist 
+als die Passung des dreifaktoriellen Modells. Insbesondere ist der inhaltliche Mehrwert 
+des dreifaktoriellen Modells fraglich, da die drei breiten Wissensdomänen hoch 
+zusammenhängen und in der Kurzskala nur durch jeweils vier Items repräsentiert 
+werden, wodurch eine substanzielle Interpretation dieser spezifischeren Faktoren 
+erschwert wird. Für das einfaktorielle Messmodell ergibt sich eine zufriedenstellende 
+Reliabilität der latenten Variable von ω = .82 (McDonald 1999) bzw. α = .81 
+(Zumbo/Gadermann/Zeisser 2007). Die Reliabilität des manifesten Summenscores 
+167 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+liegt bei .70 (Raykov/Dimitrov/Asparouhov 2010). Die entsprechenden Werte für 
+die Gesamtskala mit 32 Items liegen mit .91 (ω/α) bzw. .84 (Skalenreliabilität nach 
+Raykov et al. 2010) wegen der höheren Itemzahl erwartungsgemäß höher.
+3.3 Überprüfung von Boden- und Deckeneffekten
+Da bei Kurzskalen nur wenige Items eingesetzt werden, besteht im Vergleich zu 
+umfangreicheren Skalen ein höheres Risiko von Boden- bzw. Deckeneffekten, d.h. 
+mangelnder Differenzierungsfähigkeit innerhalb von Personengruppen mit sehr 
+niedriger bzw. sehr hoher Fähigkeitsausprägung. Um zu überprüfen, ob solche 
+Tabelle 2 Fitstatistiken konkurrierender Messmodelle
+Modell χ² df CFI RMSEA WRMR
+3 Faktoren 94.9 51 .973 .027 0.97
+1 Faktor 110.8 54 .965 .030 1.06
+Anmerkungen: χ²: Chi-Quadrat-Wert; df: Anzahl der Freiheitsgrade; CFI: Comparative fit index; RMSEA: Root mean 
+square error of approximation; WRMR: Weighted root mean square residual.
+Abbildung 1 Dreifaktorielles (a) und einfaktorielles Messmodell (b) der Kurzskala
+Anmerkungen: Naturw.: Naturwissenschaften; Geistesw.: Geisteswissenschaften; Sozialw.: Sozialwissenschaften, 
+gc: kristalline Intelligenz; zu den Itembezeichnern siehe Tabelle 1.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181168 
+Effekte vorliegen, wird im Folgenden zunächst die Verteilung des Summenwerts der 
+Kurzskala in der Gesamtpopulation betrachtet (vgl. Abbildung 2). Zudem erfolgt 
+eine Betrachtung zweier Subpopulationen mit geringer bzw. hoher Schulbildung 
+(vgl. Abbildung 3). Die Subpopulation mit „geringer Schulbildung“ umfasst sowohl 
+Personen ohne Schulabschluss als auch Personen mit Hauptschulabschluss (bzw. 
+Äquivalent), die in der Regel nach der achten oder neunten Klasse die allgemeinbildende 
+Schule verlassen haben. Ihr Anteil an der erwachsenen deutschen Wohnbevölkerung 
+beträgt gemäß der vorliegenden Erhebung 45%. Personen mit „hoher 
+Schulbildung“ im Sinne der hier vorgenommenen Analyse verfügen demgegenüber 
+über eine fachgebundene oder allgemeine Hochschulreife bzw. Fachhochschulreife 
+(26% der Gesamtpopulation), die typischerweise nach 12 oder 13 Jahren Schulbesuch 
+erworben wurde. 
+Tabelle 3 gibt die Kennwerte der Verteilungen wieder. Für die Gesamtpopulation 
+zeigen sich keine nennenswerten Boden- oder Deckeneffekte. Zwar liegt eine 
+gering negative Schiefe vor, d.h. am oberen Ende der Fähigkeitsskala ist die Differenzierungsfähigkeit 
+minimal geringer. Dies ist jedoch praktisch kaum bedeutsam: 
+Der Anteil der Personen, die alle Wissensitems der Kurzskala richtig beantworten 
+können, liegt in der Gesamtpopulation unter vier Prozent; im Mittel werden etwa 
+sieben Items richtig gelöst. Ein differenzierteres Bild ergibt sich erwartungsgemäß 
+für die zwei betrachteten Subpopulationen, die sich in der mittleren Lösungshäufigkeit 
+deutlich unterscheiden. Während Personen mit „geringer Schulbildung“ im 
+Mittel weniger als sechs Items richtig beantworten, liegt der Mittelwert in der Subpopulation 
+mit „hoher Schulbildung“ etwas unter neun Items. Konkret beträgt die 
+standardisierte Mittelwertdifferenz zwischen den beiden Subpopulationen d = 1.12 
+Standardabweichungseinheiten. In der relativ großen Gruppe der Personen ohne 
+Schulabschluss bzw. mit Hauptschulabschluss liegt kein Bodeneffekt vor, hier liegt 
+die Schiefe nahe null. Für die kleinere Gruppe der Personen mit Hochschulreife 
+tritt erwartungsgemäß ein Deckeneffekt auf. Selbst in dieser sehr leistungsstarken 
+Personengruppe liegt jedoch der Anteil derer, die alle Items richtig beantworten, 
+unter 10 Prozent.
+3.4 Zusammenhänge mit Kriterien
+Ein wesentlicher Aspekt bei der Entwicklung und Beurteilung von Kurzskalen 
+besteht in deren Beziehungen zu relevanten Personen- und Umweltmerkmalen 
+sowie anderen psychologischen Konstrukten. Diese sollen einerseits im Einklang 
+mit der Literatur stehen (Konstruktvalidierung). Andererseits sollen die für die 
+Kurzskala ermittelten Beziehungen möglichst den Befunden für die ungekürzte 
+169 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Abbildung 2 Verteilung des Summenwerts der Kurzskala in der 
+Gesamtpopulation
+Abbildung 3 Verteilung des Summenwerts der Kurzskala in zwei 
+Subpopulationen
+Tabelle 3 Kennwerte verschiedener Personenverteilungen für den 
+Summenwert der Kurzskala
+Population N M SD Schiefe Exzess
+Gesamtpopulation 1.134 7.04 2.66 -0.20 0.64„Geringe 
+Schulbildung“ 514 5.95 2.49 +0.06 0.17„Hohe 
+Schulbildung“ 290 8.66 2.27 -0.52 0.38Anmerkungen: 
+N: Stichprobengröße; M: arithmetisches Mittel; SD: Standardabweichung.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181170 
+Gesamtskala entsprechen, um sicherzustellen, dass die Itemselektion keine substanzielle 
+Minderung der Konstruktvalidität zur Folge hat (Widaman/Little/Preacher/
+Sawalani 2011). Im Folgenden werden daher die Korrelationen der Kurzskala mit 
+verschiedenen Kovariaten näher betrachtet und den entsprechenden Korrelationen 
+der Gesamtskala mit 32 Wissensitems gegenübergestellt (vgl. Tabelle 4). Zu 
+den betrachteten Personenvariablen zählen Geschlecht, Alter, formale Bildung und 
+sozioökonomischer Status der Teilnehmenden. Darüber hinaus werden an dieser 
+Stelle auch Merkmale des Haushalts der Befragten (Haushaltsnettoeinkommen) 
+sowie des elterlichen Haushalts analysiert (sozioökonomischer Status der Eltern, 
+Anzahl der Bücher im elterlichen Haushalt zur Jugendzeit der Teilnehmenden), 
+die als Indikatoren für Umfang und Reichhaltigkeit der früheren oder aktuellen 
+Lernumwelt angesehen werden. Mit Blick auf psychologische Konstrukte werden 
+die Beziehungen zu den fünf Hauptdimensionen der Persönlichkeit (Big Five) und 
+zu selbstberichtetem Wissen untersucht. Bei der Interpretation der im folgenden 
+dargestellten Beziehungen ist zu beachten, dass es sich um messfehlerbehaftete 
+Korrelationen zwischen manifesten Variablen handelt. Zur Einordnung der Größe 
+der Effekte kann eine Orientierung an Cohen (1988) erfolgen, der für Produkt-MomentKorrelationen 
+Werte um .10 als kleine Effekte, Werte um .30 als mittlere 
+Effekte und Werte um .50 als große Effekte betrachtet. Wesentlicher ist jedoch der 
+Vergleich der hier ermittelten Zusammenhänge mit den in der Einleitung dargestellten 
+Erwartungen.
+In Übereinstimmung mit der Literatur zeigen Männer etwas höhere Wissensleistungen 
+als Frauen. Die standardisierte Mittelwertdifferenz beträgt d = 
+.30 und ist somit inhaltlich bedeutsam, obgleich niedriger als von Ackerman et 
+al. (2001) berichtet4. Wie erwartet wird in der hier untersuchten Erwachsenenpopulation 
+kein bedeutsamer Alterseffekt beobachtet. Deklaratives Wissen weist 
+eine hohe positive Korrelation mit dem ISCED-97 als Indikator formaler Bildung 
+auf, der sowohl Schul- als auch Ausbildungsabschlüsse berücksichtigt: Für 
+kein anderes hier untersuchtes Personen- oder Umweltmerkmal wurden höhere 
+Korrelationen gefunden. Eine ebenfalls starke Beziehung zeigt sich zu dem 
+auf der ISEI-Skala quantifizierten sozioökonomischen Status der Teilnehmenden. 
+Auch für die anderen in Tabelle 4 genannten Personen- und Haushalts4 
+Für Männer und Frauen kann von Messinvarianz ausgegangen werden, d.h. die Kurzskala 
+misst in beiden Gruppen dasselbe Konstrukt mit vergleichbarer Genauigkeit. Ein 
+entsprechend restringiertes Multigruppenmodell unter Annahme strikter Messinvarianz 
+zeigte sowohl für die Kurzskala mit 12 Items als auch für die Gesamtskala mit 
+32 Wissensitems eine befriedigende Passung (Werte für die Kurzskala: χ² = 203.7, 
+df = 130, RMSEA = .032, CFI = .953, WRMR = 1.548). Der latente Mittelwertunterschied 
+betrug 0.32 SD zugunsten der Männer.
+171 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+merkmale liegen inhaltlich bedeutsame positive Korrelationen mit Wissen vor, 
+die jedoch niedriger als die Zusammenhänge mit ISCED-97 und ISEI ausfallen. 
+Mit Blick auf die psychologischen Konstrukte liegt erwartungsgemäß eine 
+vergleichsweise hohe Korrelation mit selbstberichtetem Wissen vor. Für die fünf 
+Persönlichkeitsdimensionen ergibt sich ein differenziertes Ergebnismuster, das im 
+Wesentlichen mit den in der Literatur berichteten Befunden übereinstimmt. Die 
+Offenheitsdimension weist im Vergleich mit den anderen Big Five-Dimensionen die 
+vom Betrag her höchste Korrelation mit Wissen auf. Auch die gering positive Korrelation 
+mit Extraversion, die gering negative Beziehung zu Neurotizismus sowie die 
+nicht signifikante Korrelation mit Verträglichkeit entsprechen den metaanalytisch 
+gewonnenen Ergebnissen von Ackerman und Heggestad (1997). Eine Abweichung 
+lässt sich allein für Gewissenhaftigkeit feststellen: Während Ackerman und Heggestad 
+(1997) hier eine negative Korrelation mit Wissen bzw. eine nicht signifikante 
+Tabelle 4 Korrelationen der Kurz- und Gesamtskala mit verschiedenen 
+Personen- und Haushaltsmerkmalen sowie psychologischen 
+Konstrukten
+Variable Nvi
+Kurzskala Gesamtskala
+r SE r SE
+Geschlecht1 1.134 -.15 .03 -.15 .03
+Alter 1.134 .01n.s. .03 .00 n.s. .03
+ISCED-97 1.091 .49 .03 .51 .03
+ISEI 388 .44 .04 .45 .04
+HISEI Eltern 1.082 .25 .03 .25 .03
+Einkommen 638 .29 .04 .30 .04
+Anzahl Bücher 1.101 .30 .03 .33 .03
+selbstber. Wissen2 1.134 .52 .03 .55 .03
+Neurotizismus3 1.104 -.10 .03 -.15 .03
+Extraversion3 1.104 .07a .04 .12 .04
+Offenheit3 1.104 .21 .03 .25 .03
+Gewissenhaftigkeit3 1.104 .07a .03 .09 .03
+Verträglichkeit3 1.104 -.02n.s. .03 -.02 n.s. .03
+Anmerkungen: N = 1.134. 1 0 = männlich, 1 = weiblich; 2 selbstberichtetes Wissen (VOC-T Treffer); 3 Big Five-Dimensionen; 
+a p < .05; n.s. nicht signifikant; Nvi: Fallzahl vor der Imputation; r: punkt-biseriale Korrelation (Geschlecht), 
+polyseriale Korrelation (ISCED-97, Bücher), Produkt-Moment-Korrelation (alle anderen Variablen); SE: Standardfehler; 
+ISCED-97: International Standard Classification of Education, Fassung 1997; ISEI: International SocioEconomic 
+Index of Occupational Status; HISEI Eltern: Höchster ISEI-Wert der beiden Elternteile des Teilnehmenden. 
+Sofern nicht anders gekennzeichnet, sind alle Korrelationen signifikant von null verschieden (p < .01).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181172 
+Korrelation mit kristalliner Intelligenz berichten, wird in der aktuellen Analyse eine 
+gering positive Beziehung zwischen Wissen und Gewissenhaftigkeit gefunden. Für 
+alle berichteten Kovariaten ergeben sich im Vergleich von Kurz- und Gesamtskala 
+sehr ähnliche Korrelationen. 
+4 Diskussion
+Da der Umfrageforschung im deutschen Sprachraum bis dato nur wenige frei verfügbare 
+und erprobte Instrumente zur Erfassung kognitiver Fähigkeiten vorliegen, 
+war das Ziel dieses Beitrags die Entwicklung einer Kurzskala zur Messung kristalliner 
+Intelligenz (gc) und die Prüfung ihrer psychometrischen Eigenschaften. Die hier 
+beschriebene Kurzskala BEFKI GC-K umfasst 12 Items, die in Übereinstimmung mit 
+der Definition von gc durch Cattell (1971) bzw. Carroll (1993) deklaratives Wissen 
+aus ebensovielen Bereichen der Natur-, Geistes- und Sozialwissenschaften erfassen. 
+Somit wird innerhalb von fünf Minuten Bearbeitungszeit ein möglichst breites 
+Wissensspektrum berücksichtigt. Durch Einbezug von Items unterschiedlicher 
+Schwierigkeit gelang es, trotz der vergleichsweise geringen Itemanzahl Boden- und 
+Deckeneffekte in der erwachsenen deutschen Wohnbevölkerung fast vollständig zu 
+vermeiden. Lediglich in der besonders leistungsstarken Subpopulation mit Hochschulabschluss 
+bzw. Fachhochschulabschluss trat ein geringer Deckeneffekt auf. 
+Weiterhin weist die Kurzskala eine gute Reliabilität auf, welche gängige Standards 
+für die Forschung erfüllt. Die zeitliche Stabilität der Testwerte konnte aufgrund der 
+querschnittlichen Natur der Erhebung nicht geprüft werden. Daten einer mit Schülerinnen 
+und Schülern der Mittelstufe durchgeführten Längsschnittuntersuchung 
+mit Wissensitems aus dem BEFKI-Pool legen jedoch eine befriedigende zeitliche 
+Stabilität nahe (Wilhelm et al., in Vorbereitung).
+Sowohl für ein einfaktorielles Messmodell als auch für ein mehrdimensionales 
+Modell, das drei korrelierte Faktoren gemäß der Unterscheidung zwischen 
+Natur-, Geistes- und Sozialwissenschaften spezifiziert, ergab sich eine zufriedenstellende 
+Passung bei statistisch signifikanter Überlegenheit des dreifaktoriellen 
+Modells. Die Bevorzugung des eindimensionalen Modells im vorliegenden Beitrag 
+beruht auf mehreren Argumenten: Erstens ist zu berücksichtigen, dass der 
+χ²-Differenztest von der Stichprobengröße abhängig ist und daher in der vorliegenden, 
+vergleichsweise großen Stichprobe auch inhaltlich unbedeutende Unterschiede 
+als signifikant ausgewiesen werden. Zweitens ist das einfaktorielle Modell 
+insofern theoretisch fundiert, als Wissen aus verschiedenen Bereichen in konsensualen 
+Intelligenzstrukturtheorien einem gemeinsamen, bereichsübergreifenden gc173 
+Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Faktor untergeordnet ist (Horn/Noll 1997; Carroll 1993, 2003; McGrew 2009). Dies 
+wird auch empirisch durch die sehr hohen Korrelationen zwischen den Wissensfaktoren 
+im dreidimensionalen Modell gestützt. Drittens ist zu berücksichtigen, 
+dass die spezifischeren Faktoren des dreidimensionalen Modells mit nur jeweils vier 
+Items extrem schmal operationalisiert sind. Eine inhaltliche Interpretation dieser 
+Faktoren wäre fragwürdig, da die Itemstichprobe aufgrund dieser sehr geringen 
+Itemzahl keine Repräsentativität für die jeweilige Wissensdomäne beanspruchen 
+kann (Ackerman 2000). Ferner ist die im Vergleich zu einem Gesamtwert geringere 
+Reliabilität von Subskalen zu berücksichtigen (Sinharay 2010). Im Extremfall kann 
+dies dazu führen, dass der Gesamttestwert einen besseren Prädiktor der Personenfähigkeit 
+auf einer Subdimension darstellt als der entsprechende Subskalenwert 
+(Sinharay/Haberman/Puhan 2007). Selbst bei vermeintlich ausreichender Reliabilität 
+einer Subskala kann diese durch die übergeordnete Fähigkeit bedingt sein statt 
+durch die spezifische Subdimension (Reise/Moore/Haviland 2010).
+Die Validität der gc-Kurzskala wurde anhand der Korrelationen des Gesamtwertes 
+mit verschiedenen Personen- und Umweltmerkmalen einerseits sowie 
+ausgewählten psychologischen Konstrukten andererseits überprüft, wobei diese 
+Beziehungen fast durchgängig mit den auf Basis der Fachliteratur formulierten 
+Erwartungen übereinstimmten. Die Höhe der untersuchten Effekte bzw. Zusammenhänge 
+lag für die Kurzskala mit 12 Items nur geringfügig unter den entsprechenden 
+Werten für die ungekürzte Wissensskala mit 32 Items; die Abweichungen 
+lassen sich durch die etwas geringere Reliabilität der Kurzskala erklären. Im Einzelnen 
+wurde übereinstimmend mit den oben zitierten Befunden ein Geschlechtsunterschied 
+im deklarativen Wissen zugunsten von Männern gefunden. Dies stellt 
+keine Verzerrung und somit unfaire Messung dar, sondern repliziert den Befund 
+von Ackerman et al. (2001), dass bei einem umfassenden Sampling von Items aus 
+vielen verschiedenen Wissensbereichen in den meisten dieser Bereiche ein Wissensvorsprung 
+der Männer zu beobachten ist. Dass der Mittelwertunterschied in 
+der hier vorgestellten Skala weniger deutlich ausfällt, könnte auf kulturelle Unterschiede 
+zurückzuführen sein oder darin begründet liegen, dass andere Studien teilweise 
+deutlich größere Itemmengen eingesetzt haben, einschließlich sehr spezifischer 
+Wissensfragen, die als berufsspezifische Expertise einzuordnen sind (vgl. den 
+gkn-Faktor im CHC-Modell; McGrew 2009). In der vorliegenden Kurzskala wurde 
+hingegen auf derartige Items zu hochspezifischem Wissen verzichtet, da sie nur 
+innerhalb bestimmter Subpopulationen funktionieren. Dies ist auch ein Grund 
+dafür, dass kein substanzieller Zusammenhang zwischen der gc-Kurzskala mit dem 
+Alter festgestellt werden konnte. Mit Blick auf die hohe Stabilität kristalliner Intelligenz 
+im Erwachsenenalter war ein kleiner oder nicht signifikanter Effekt erwartet 
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181174 
+worden. Zwar werden in der Literatur Wissenszuwächse auch im jungen und mittleren 
+Erwachsenenalter berichtet (Ackerman 2000), diese beziehen sich aber auf 
+Expertise im Sinne von Wissen, das erst im Erwachsenenalter erworben werden 
+kann, beispielsweise im Rahmen der Berufsausübung (Ackerman 1996). Zum anderen 
+umfasst die untersuchte Population neben jungen Erwachsenen auch Erwachsene 
+in sehr hohem Alter, für die in der Literatur biologisch bedingt abnehmende 
+Leistungen auch in Tests kristalliner Fähigkeiten berichtet werden (Li 2003). 
+Erwartungskonform sind ebenfalls die substanziellen positiven Beziehungen 
+der Kurzskala mit Indikatoren der formalen Bildung und der Reichhaltigkeit 
+der Lernumwelt, die im sozioökonomischen Status zum Ausdruck kommt. Sowohl 
+ISCED-97 als auch ISEI der Teilnehmenden hängen mit dem über einen langen 
+Zeitraum in einer Vielzahl von Bereichen erworbenen Wissen zusammen. Die vergleichsweise 
+niedrigeren Korrelationen mit dem sozioökonomischen Status der 
+Eltern, dem Haushaltsnettoeinkommen sowie der Anzahl der Bücher im elterlichen 
+Haushalt zur Jugendzeit der Teilnehmenden sind insofern plausibel, als es sich dabei 
+um eher indirekte bzw. inhaltlich weniger breite Indikatoren handelt, die begrenzte 
+Aussagekraft bzgl. der Lernumwelt haben. 
+Mit Blick auf andere psychologische Konstrukte konnte gezeigt werden, 
+dass eine relativ hohe positive Korrelation zwischen der Kurzskala und selbstberichtetem 
+Wissen vorliegt. Dieser Befund überrascht nicht, da beide Skalen auf 
+deklaratives Wissen abzielen und die Auswahl der erfassten Wissensbereiche in 
+beiden Messverfahren auf der Systematik von Ackerman (2000) beruht. Dass kein 
+perfekter Zusammenhang vorliegt, dürfte – neben der Tatsache, dass die berichteten 
+Korrelationen messfehlerbehaftet sind – insbesondere an der unterschiedlichen 
+Natur der Messverfahren liegen (Selbstauskünfte versus tatsächliches Wissen). Die 
+Beziehungen der gc-Kurzskala zu den Big Five zeigten ein Korrelationsmuster, das 
+mit den metaanalytischen Befunden von Ackerman und Heggestad (1997) weitgehend 
+übereinstimmt. Die höchste Korrelation wies die gc-Kurzskala wie erwartet 
+mit der Offenheitsdimension auf. Im Widerspruch zu den Ergebnissen von Ackerman 
+und Heggestad (1997) steht lediglich die leicht positive Korrelation mit der 
+Gewissenhaftigkeitsdimension. Hierbei ist jedoch zu bedenken, dass die diesbezügliche 
+Datenbasis in der genannten Metaanalyse sehr klein war und ein gering 
+positiver Zusammenhang zwischen Gewissenhaftigkeit und Wissensleistungen aus 
+theoretischer Sicht erklärbar ist. Man denke etwa an die umfangreiche Literatur 
+zur prädiktiven Validität von Gewissenhaftigkeit für den Berufserfolg (Barrick/
+Mount/Judge 2001). Befunde zu den Beziehungen der Kurzskala mit anderen gcIndikatoren 
+sowie mit gf liegen bisher nur für Langformen aus Pilotierungs- und 
+Normierungsstudien vor, die mit Schülerpopulationen durchgeführt wurden. Auf 
+175 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+der Ebene latenter Variablen konnte bei Schülerinnen und Schülern der achten bis 
+zehnten Jahrgangsstufe eine hohe Korrelation zwischen deklarativem Wissen und 
+Wortschatz (ρ = .93) und eine ebenfalls substanzielle Beziehung zwischen Wissen 
+und schlussfolgerndem Denken (ρ = .80) gezeigt werden (Wilhelm et al., in Vorbereitung).Bei 
+der Interpretation der im vorliegenden Beitrag berichteten Befunde ist 
+einschränkend zu berücksichtigen, dass die Itemselektion für die Kurzskala und 
+deren Evaluation auf derselben Erhebung basieren. Zudem lag für den Wissenstest 
+eine relativ strenge Zeitbegrenzung vor, die zu fehlenden Werten führte, da nicht 
+alle teilnehmenden Personen den Test in der vorgegebenen Zeit abschließen konnten. 
+Diese aufgrund der Zeitbegrenzung fehlenden Werte als Falschantworten zu 
+werten, hätte eine Verzerrung des Skalenwerts durch konstruktirrelevante Varianz 
+– etwa Unterschiede in mentaler Geschwindigkeit – zur Folge gehabt. Um diese 
+Verzerrung zu vermeiden, wurden daher fehlende Werte unter Berücksichtigung 
+aller verfügbaren Informationen imputiert; dadurch ist die größtmögliche Vergleichbarkeit 
+mit einer Durchführung ohne Zeitmangel gewährleistet. Eine Bearbeitungzeit 
+von fünf Minuten für die 12 Items der Kurzskala ist jedoch ausreichend, 
+so dass eine Imputation fehlender Werte unter diesen Durchführungsbedingungen 
+nicht erforderlich ist (stattdessen sollten ausgelassene Items wie Falschantworten 
+ausgewertet werden). In zukünftigen Studien sollte geprüft werden, inwiefern die 
+hier berichteten Befunde auf andere Stichproben und die veränderten Durchführungsbedingungen 
+übertragbar sind.
+5 Abschließende Bemerkungen
+Die hier vorgestellte Kurzskala BEFKI GC-K zur Erfassung kristalliner Intelligenz 
+stellt unseres Wissens das erste frei verfügbare Verfahren zur gc-Messung dar, das 
+sich aufgrund seiner Kürze und psychometrischen Effizienz für den Einsatz in der 
+Umfrageforschung eignet. Die Skala ist sowohl in technologiebasierten Testungen 
+(computer assisted personal interview/self-interview/web-interview) als auch bei 
+herkömmlichen Papier-Stift-Testungen (Selbstausfüller) leicht anzuwenden; neben 
+Einzeltestungen sind auch Gruppentestungen problemlos möglich. Einschränkend 
+gilt hier, dass die Bewährung der Kurzskala mit anderen Testmedien bislang nicht 
+geprüft wurde. Mit Blick auf die umfangreiche Literatur zu Testmedienvergleichen 
+(vgl. etwa Mead/Drasgow 1993; Schroeders/Wilhelm 2010) sind für die gc-Skala 
+bei ansonsten gleichen Durchführungsbedingungen jedoch keine nennenswerten 
+Testmedieneffekte zu erwarten. Gegenüber gängigen Bildungsindikatoren wie 
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181176 
+der ISCED-97 hat die Wissensskala den Vorteil, dass tatsächliches Wissen direkt 
+erhoben wird, anstatt es aus Abschlüssen zu erschließen. Letzteres ist insbesondere 
+deshalb problematisch, da Schul- und Ausbildungsabschlüsse einerseits zwischen 
+verschiedenen Bundesländern oder gar Staaten schwer vergleichbar sind 
+(Neumann/Nagy/Trautwein/Lüdtke 2009) und formale Abschlüsse andererseits 
+dem zeitlichen Wandel unterliegen. Zudem sind Selbstauskünfte wie Angaben zu 
+Bildungsabschlüssen oder zur Berufstätigkeit im Gegensatz zu objektiven Leistungstests 
+leicht verfälschbar (Ziegler/MacCann/Roberts 2011). Ungeachtet der 
+Vorzüge der hier vorgestellten gc-Skala ist jedoch zu berücksichtigen, dass es sich 
+um eine Kurzskala handelt, die zur Wissensmessung in der sehr bildungsheterogenen 
+erwachsenen Bevölkerung konstruiert wurde. Daher ist die inhaltliche Breite 
+der Messung stark eingeschränkt und kann eine differenzierte Wissensdiagnostik 
+nicht ersetzen. Stattdessen fokussiert die Kurzskala auf „Wissen, von dem angenommen 
+werden kann, dass es von einem großen Teil der Population geteilt wird“ 
+(Ackerman 2003: 16). Mithilfe komplexer Testdesigns und Modellierungsmethoden 
+ist es jedoch möglich, die Vorzüge von Kurzskalen mit den Vorteilen umfangreicher 
+Messinstrumente zu kombinieren (Rhemtulla/Little 2012).
+Die Kurzskala kann für nicht-kommerzielle Forschungszwecke kostenfrei 
+eingesetzt werden. Eine Druckvorlage ist über folgenden Link verfügbar:
+http://befki.de/materialien (Kennwort: trgw34785bns)
+Anschrift des Autors Stefan Schipolowski
+ Humboldt-Universität zu Berlin
+ Institut zur Qualitätsentwicklung im Bildungswesen
+ Unter den Linden 6
+ 10099 Berlin
+ stefan.schipolowski@iqb.hu-berlin.deKo-Autor/innen 
+Oliver Wilhelm
+ Institut für Psychologie und Pädagogik
+ Universität Ulm
+ Ulrich Schroeders
+ Institut zur Qualitätsentwicklung im Bildungswesen
+ Humboldt-Universität zu Berlin
+ Anastassiya Kovaleva
+ Fakultät für Biologie, Universität Bielefeld
+ Christoph J. Kemper
+ Institut für medizinische und pharmazeutische 
+ Prüfungsfragen, Mainz
+ Beatrice Rammstedt
+ GESIS – Leibniz-Institut für Sozialwissenschaften, 
+ Mannheim
+ 

--- a/src/test/resources/bibExtractor/test/31452.txt
+++ b/src/test/resources/bibExtractor/test/31452.txt
@@ -1,0 +1,488 @@
+www.ssoar.info
+Rezension: Sigrid Haunberger, 2011:
+Teilnahmeverweigerung in Panelstudien
+Lipps, Oliver
+Veröffentlichungsversion / Published Version
+Rezension / review
+Zur Verfügung gestellt in Kooperation mit / provided in cooperation with:
+GESIS - Leibniz-Institut für Sozialwissenschaften
+Empfohlene Zitierung / Suggested Citation:
+Lipps, Oliver (Rev.): Haunberger, Sigrid: Teilnahmeverweigerung in Panelstudien. Wiesbaden: VS Verl. für Sozialwiss.,
+2011. In: Methoden, Daten, Analysen (mda) 6 (2012), 1, pp. 49-53. URN: http://nbn-resolving.de/urn:nbn:de:0168-ssoar314523Nutzungsbedingungen:Dieser 
+Text wird unter einer CC BY Lizenz (Namensnennung) zur
+Verfügung gestellt. Nähere Auskünfte zu den CC-Lizenzen finden
+Sie hier:
+http://creativecommons.org/licenses/
+Terms of use:
+This document is made available under a CC BY Licence
+(Attribution). For more Information see:
+http://creativecommons.org/licenses/
+49 Rezensionen
+ringern sie den Umfang der realisierten 
+Stichprobe und bedingen daher größere 
+Stichprobenfehler. Last but not least ist sich 
+die mittlerweise recht umfangreiche Literatur 
+im Bereich der Nonresponseforschung in 
+der Einschätzung einig, dass Nonresponse 
+tendenziell zunimmt. 
+Die Einhaltung gewisser Grenzen von Nonresponse 
+stellt daher immer größere Anforderungen 
+an Erhebungsdesign und -ressourcen. 
+Dessen ungeachtet ist – wie die 
+Autorin des vorliegenden Buchs treffend 
+feststellt – „bezüglich der Erklärung systematischer 
+Ausfälle von Teilnehmern kaum 
+ein Fortschritt zu verzeichnen“ (S. 18). Dies 
+liegt daran, dass nach wie vor meist ausschließlich 
+sozio-demografische Variablen 
+wie Alter und Geschlecht nicht nur zur 
+Beschreibung, sondern auch zur Erklärung 
+von Nonresponse verwendet werden. Der 
+simple Grund ist, dass – wenn überhaupt – 
+von Nichtteilnehmern nur solche Variablen 
+bekannt sind; noch häufiger lediglich Randverteilungen. 
+Im Sinne einer Erklärung der 
+Prozesse und Mechanismen, die zur Teilnahme 
+oder Nichtteilnahme führen, sind 
+solche Variablen aber wenig geeignet.
+Sigrid Haunbergers im VS Verlag veröffentlichte 
+Dissertation ist ein äußerst lobenswertes 
+Plädoyer, sich für die Erklärung 
+von Nonresponse und Attrition von einer 
+solchen „Variablensoziologie“ zu lösen. Die 
+Autorin schlägt stattdessen zwei handlungstheoretische 
+Theorien vor: die Theory 
+of planned behavior (TOPB) und die Theory 
+of subjective expected utility (SEU). Sie 
+motiviert, operationalisiert und testet diese 
+empirisch anhand einer Stichprobe von Studierenden 
+mit Hilfe einer Onlineerhebung. 
+Insofern dürfte sich das Buch vor allem an 
+Erhebungsexperten aus Theorie und Praxis 
+richten, die Interesse an der Erklärung von 
+Nonresponse und Attrition haben. Speziell 
+eignet sich dieses Buch sehr gut als Grundlage 
+für weitergehende empirische Forschungsarbeiten 
+oder Experimente, Mechanismen 
+für Nonresponse auf der Grundlage der in 
+lungen auch Ansätze zur „Bestimmung des 
+Standorts und des weiteren Kurses“ (S. V). In 
+Bezug auf diese, im Geleitwort von Wilfried 
+Seidel genannte Zielsetzung wären eventuell 
+eine europäische oder internationale Situationsbetrachtung 
+oder Vergleiche mit anderen 
+statistischen Fachgesellschaften ein eigenes 
+Kapitel wert gewesen. Aufgrund der historischen 
+und fachlichen Synopsen ist der Band 
+aber nicht nur „ein Buch für die Freunde der 
+Statistik und der Deutschen Statistischen 
+Gesellschaft“ (S. IX), sondern auch für den 
+Einsatz in der universitären Lehre geeignet, 
+z. B. in Einführungen in die Wirtschafts- und 
+Sozialstatistik, und nicht zuletzt für alle 
+Anwender und Nutzer von statistischen Verfahren 
+und Daten interessant. 
+BernHard ScHimpl-neimannS, mannHeim
+* * * * *
+SiGrid HaunBerGer, 
+2011: Teilnahmeverweigerung 
+
+in Panelstudien. 
+VS-Verlag. ISBN: 
+978-3-531-17710-6, 
+254 Seiten, 39,95 
+EUR.
+Nicht (Nonresponse) bzw. nicht mehr (Attrition) 
+befragte Mitglieder von Zufallsstichproben 
+unterscheiden sich in aller Regel 
+systematisch von den Teilnehmern. Nonresponse 
+und Attrition sind wichtige, wenn 
+nicht sogar die wichtigsten Gründe für die 
+Verzerrung von Stichprobenparametern und 
+sta tis tischen Zusammenhängen. Zudem verMethoden 
+— Daten — Analysen · 2012, Jg. 6, Heft 150 
+dieser Arbeit verwendeten handlungstheoretischen 
+Theorien aufzudecken.
+Die einzelnen Kapitel bauen sinnvoll aufeinander 
+auf; das Buch liest sich leicht, was 
+auch einigen Wiederholungen von komplexeren 
+Sachverhalten zu verdanken ist. Die 
+Arbeit startet in Kapitel A mit einer sehr 
+guten Dokumentation der zunehmenden 
+Relevanz, Komplexität, und Popularität des 
+Themas Nonresponse. Die Autorin beanstandet, 
+dass sich in der umfangreichen 
+Literatur nur wenige Autoren finden, die 
+Non response nicht mittels soziodemografischen 
+(und anderen gerade zur Verfügung 
+stehenden Korrelaten) erklären, sondern 
+handlungstheoretisch fundierte Modelle 
+verwenden. Aber auch falls dies der Fall ist, 
+ist nach Ansicht der Autorin die Operationalisierung 
+der Theorie unzureichend. Die 
+geeignete Operationalisierung der beiden 
+Theorien stellt – neben dem empirischen 
+Test – in der vorliegenden Arbeit die Hauptzielsetzung 
+dar. Kapitel B bespricht Panelstudien 
+mit ihren analytischen Vorteilen, 
+erhebungsspezifischen Problemen und der 
+Vielschichtigkeit der Ausprägungen von 
+Nonresponse. Insbesondere können bei 
+Panelerhebungen Stichprobenmitglieder 
+nicht nur in der ersten Befragungswelle 
+ausfallen, sondern auch erst nach einer 
+gewissen Teilnahmedauer endgültig oder 
+temporär nicht (mehr) teilnehmen (Attrition). 
+Kapitel C diskutiert den aktuellen 
+Forschungsstand zu Non response, wobei 
+zwischen Nichterreichbarkeit und Verweigerung 
+differenziert wird. Diese Differenzierung 
+ist wichtig, da Motivation und 
+Hintergrund für diese beiden Ursachen 
+verschieden sind. Die Autorin kritisiert, 
+dass die verwendeten empirischen Modelle 
+zur Erklärung von Nichterreichbarkeit und 
+Verweigerung nur selten theoriegeleitet 
+sind und dementsprechend besonders bei 
+befragtenbezogenen Faktoren heterogene 
+Ergebnisse produzieren. Die „Theorien“ zur 
+Erklärung der Wirkungsmechanismen von 
+Nonresponse werden erläutert. Bemängelt 
+wird, dass sie meist bei Einzelaspekten 
+ansetzen (etwa Incentives) und oft die 
+Handlungsdispositionen der Stichprobenmitglieder 
+ignorieren. Die Autorin stellt 
+fest, dass Gründe für Verweigerungen oft 
+situativ sind. Dies vor allem aufgrund der 
+Tatsache, dass „eine Teilnahmeentscheidung 
+… aus einem Zustand der Indifferenz heraus 
+erfolgt“ (S. 96). Entsprechend müsste eine 
+handlungstheoretisch bedeutsame Erklärung 
+die subjektive Situation als relevante 
+Variable operationalisieren. In Kapitel D 
+werden die beiden handlungstheoretischen 
+Modelle des Teilnahmeverhaltens vorgestellt: 
+Die SEU enthält die Bewertungen von 
+und Erwartungen an möglichst alle zur Verfügung 
+stehenden Handlungsalternativen 
+als handlungserklärende Variablen; die TOPB 
+‚verhaltensbezogene Einstellung’, ‚subjektive 
+Norm’, und ‚wahrgenommene Verhaltenskontrolle’. 
+Wichtig sind die Prämissen, 
+dass Subjekte nicht voll rational/informiert 
+handeln, und dass das Handeln aus einer 
+bestimmten Situation heraus erklärt werden 
+muss. Zusätzlich spielen Routinen und 
+in ähnlichen Situationen bewährte Handlungsweisen 
+eine Rolle. Die Autorin erläutert 
+die Operationalisierung der beiden Theorien 
+zu quantitativen Modellen. Kapitel  E 
+beschreibt den empirischen Test der beiden 
+handlungstheoretischen Modelle. Die 
+Stichprobe besteht aus Studierenden der 
+Universität Bern aus verschiedenen, meist 
+sozialwissenschaftlichen Vorlesungen. Diese 
+werden zunächst in einer Paper  &  Pencil 
+„Null“messung über ihre Basischarakteristika 
+sowie – in zwei Gruppen randomisiert 
+– ihre handlungstheoretisch relevanten 
+Teilnahmedispositionen bezüglich 
+der Komponenten der SEU und der TOPB 
+befragt. Zudem werden die E-Mail Adressen 
+erfragt, wobei hier (Angabe oder eben 
+Nichtangabe der E-Mail Adresse) eine erste 
+Selektion erfolgt. Einige Zeit danach werden 
+die Befragten per E-Mail gebeten, bei einer 
+zwei Wellen umfassenden Online-Erhebung 
+über Drogen teilzunehmen. Hierbei erfolgt 
+die zweite und dritte Möglichkeit der Nonresponse. 
+In Kapitel F werden schließlich 
+die Ergebnisse interpretiert und Schluss51 Rezensionenfolgerungen 
+gezogen. Während mit beiden 
+Theorien die Teilnahmeintention relativ gut 
+erklärt wird, fällt die Erklärungskraft für 
+das tatsächliche Verhalten deutlich geringer 
+aus. Bei der TOPB sind es vor allem 
+modellexogene Faktoren, wie die subjektive 
+Entscheidungssicherheit und vergangene 
+Teilnahmehäufigkeit, bei der SEU Kostenbefürchtungen 
+und Situationsmerkmale, die 
+das tatsächliche Teilnahmeverhalten erklären. 
+Die Autorin folgert, dass die Theorien 
+trotz ihrer geringen Erklärungskraft zur 
+Erklärung des Teilnahmeverhaltens geeignet 
+sind. Sie schließt mit einer Kritik der 
+Resultate und der Diskussion weiterer Forschungsmöglichkeiten.Die 
+besonderen Stärken der Arbeit liegen in 
+der gut begründeten Kritik der konventionellen 
+Modelle zur Erklärung des Teilnahmeverhaltens 
+und der Motivation und Operationalisierung 
+der beiden Theorien SEU und 
+TOPB. Was ebenfalls bei einer Dissertation 
+nicht unbedingt erwartet werden kann, ist 
+der große Umfang der zitierten Literatur. Als 
+kleiner Wermutstropfen kann einzig festgehalten 
+werden, dass einzelne neuere Forschungsergebnisse 
+unerwähnt bleiben. So 
+hätte man etwa in Kapitel B, §1.2 einen Hinweis 
+darauf begrüßt, dass bei Stichprobenmitgliedern 
+gerade Veränderungen – die mit 
+Panelerhebungen ja insbesondere gemessen 
+werden sollen – zu erhöhter Attrition führen 
+(Ansätze z. B. in Voorpostel/Lipps 2011). 
+Dies zieht tendenziell eine Unterschätzung 
+von Veränderungen nach sich. Auch wäre 
+in Kapitel B, §2.6 (und auf S. 59) die Zitierung 
+der zwischenzeitlich etablierten Standardcodes 
+von finalen Ausfallsgründen der 
+American Association for Public Opinion 
+Research (AAPOR 2011) sinnvoll. Zudem 
+wäre eine stärkere Differenzierung von Nonresponse 
+bei Querschnittstudien einerseits, 
+die im Vergleich damit höhere Nonresponse 
+bei der ersten Welle einer Panelstudie andererseits, 
+und schließlich Panelattrition wünschenswert. 
+Auch wäre die Erwähnung von 
+Ansätzen zur Abschätzung von Verzerrungen 
+durch Nonresponse und Attrition auf 
+Individualebene mit Hilfe von Registerdaten 
+möglich (z. B. im CHINTEX Projekt mit ECHP 
+Daten, vgl. Ehling et al. 2003; Røed 2006). 
+Im Zusammenhang mit dem Vergleich von 
+Nonresponse Raten und Nonresponse Verzerrung 
+(Kapitel B, §3.2) hätte die Studie 
+von Groves und Peytcheva (2008) erwähnt 
+werden können. Zudem wäre ein Hinweis 
+auf R-Indikatoren (Schouten et al. 2009) 
+als Beispiel eines neuen Qualitätsindikators 
+für die Repräsentativität von Befragungen 
+willkommen. Entgegen der Kritik der mangelhaften 
+Dokumentation der Stichprobenrealisierung 
+bei Erhebungen gibt es Gegenbeispiele, 
+z. B. beim European Social Survey 
+(vergleiche die Methodenberichte zur Feldarbeit 
+im ESS auf der ESS Website http://ess.
+nsd.uib.no/). Im Kapitel C hätte eine kurze 
+Diskussion des Ausmaßes der Verzerrung 
+durch Nichtkontakt einerseits und Verweigerung 
+andererseits erfolgen können (etwa 
+Lynn/Clarke 2002). Am Ende hätte man sich 
+einen Anhang mit den verwendeten Fragebögen 
+(inklusive der Studienbeschreibung 
+bei der Nullmessung, vgl. S. 173) gewünscht; 
+möglicherweise auch ein Glossar.
+Allerdings muss ausdrücklich betont werden, 
+dass die vorliegende Arbeit meines 
+Erachtens die üblichen Anforderungen an 
+eine Dissertation sowohl in Bezug auf den 
+empirischen Teil als auch insbesondere auf 
+den theoretischen Teil weit mehr als erfüllt. 
+Etwaige Kritik muss im Kontext der insgesamt 
+sehr hohen Qualität der Arbeit und des 
+vermutlich geringen zur Verfügung stehenden 
+finanziellen Budgets für die Datenerhebung 
+beurteilt werden. Kleinere Mängel 
+im Text (Schreibfehler, Bezüge auf Tabelleninhalte, 
+vergessene Aufnahme zitierter 
+Literatur im Verzeichnis) und beim Fragebogen 
+(etwa Verlabelung der Endpunkte als 
+„sicher“, nicht nur als „sehr wahrscheinlich“ 
+wie auf S. 178) dürfen nicht überbewertet 
+werden. Ich erlaube mir lediglich eine 
+Überlegung dazu, warum die Modellvariablen 
+insbesondere auf das tatsächliche Teilnahmeverhalten 
+einen so geringen Einfluss 
+haben: Erstens werden in der Nullmessung 
+Methoden — Daten — Analysen · 2012, Jg. 6, Heft 152 
+die Effekte von fast allen befragungsbezogenen 
+Variablen (Ausnahme Incentives) 
+auf das selbst eingeschätzte hypothetische 
+Teilnahmeverhalten erhoben und nicht bei 
+der eigentlichen Befragung experimentell 
+variiert. Damit ist es wohl wahrscheinlich, 
+dass die Modellvariablen einen Einfluss auf 
+das intendierte Teilnahmeverhalten haben. 
+Der Einfluss auf das tatsächliche Verhalten 
+aber steht und fällt dann mit dem Zusammenhang 
+zwischen dem intendierten und 
+dem tatsächlichen Verhalten. Dieser Zusammenhang 
+ist aber aufgrund der vermuteten 
+starken Wirkung situativer1 Umstände 
+nicht zu erwarten. Außerdem überlegt die 
+Autorin, ob „das Teilnahmeverhalten …
+für Studierende habituell abläuft … als 
+Gewohnheit anzusehen [ist, so dass] das 
+Intentionsmaß irrelevant [wird]“ (S. 223).2 
+Zweitens zeigt ein Vergleich der bestehenden 
+Anwendungen des SEU Modells (Kapitel 
+D, §4.4) und des TOPB Modells (Kapitel 
+D, §5.3, Kap. F, §2.1) mit der Entscheidung, 
+an einer (kurzen) Onlineerhebung teilzunehmen, 
+dass letztere Entscheidung relativ 
+unbedeutend ist. Aus diesem Grund würde 
+man sich eine möglichst große Varianz der 
+modellierten befragten- und befragungsbezogenen 
+Einflussvariablen wünschen. Nun 
+ist die gewählte Stichprobe äußerst homogen.3 
+Mehr Varianz bei den Befragten hätte 
+etwa durch den Einbezug von mehr Universitäten, 
+mehr Nicht-Sozialwissenschaftlern, 
+oder auch Aufnahme von Nichtstudierenden 
+realisiert werden können. Beim Befra1 
+Befragungsthema, -dauer und Auftraggeber würde 
+ich nicht als situativ sondern als befragungsbezogen 
+betrachten.
+2 Diese Hypothese ließe sich anhand der Zeitspanne 
+zwischen Erhalt der E-Mail Aufforderung zur Teilnahme 
+und dem Zeitpunkt des Beginns der Befragung 
+testen. Bei den Teilnehmern, die die Befragung 
+spontan ausfüllen, sollte die Intention geringer sein 
+als bei denen, die sich länger Zeit lassen.
+3 Natürlich hat die gewählte Stichprobe den Vorteil 
+der kosten- und aufwandgünstigen Erhebung der 
+Probanden vor Ort sowie eine nahezu 100% Teilnahme 
+bei der Nullmessung.
+gungsdesign hätte eine tatsächliche Variation 
+von befragungsbezogenen Elementen 
+wie eine Randomisierung des Sponsors oder 
+des Befragungsthemas erfolgen können. 
+Natürlich setzt die geringe Stichprobengröße 
+hierbei enge Grenzen.4 Zudem wäre 
+eine – von der Autorin wegen unvollständigem 
+Rücklauf kritisierten – Nonresponse 
+follow-up bei nicht angegebenen E-Mail 
+Adressen möglich gewesen. Diese Kritiken 
+werden aber zum Teil bereits von der Autorin 
+problematisiert. 
+Eine vorsichtige Schlussfolgerung der 
+Ergebnisse könnte sein, dass insgesamt 
+nicht so sehr auf die (totale) Erklärungskraft 
+des tatsächlichen Teilnahmeverhaltens 
+durch die Variablen der beiden Modelle 
+fokussiert wird, sondern auf Einzelbefunde. 
+So könnte die Berücksichtigung der Tatsache, 
+dass Kostenkomponenten für verschiedene 
+Stichprobenmitglieder eine 
+unterschiedliche Wirkung haben können, 
+interessant sein. Zur besseren Erklärung 
+des Teilnahmeverhaltens könnte in Zukunft 
+mehr Gewicht auf das habitualisierte Verhalten 
+und situative Umstände gelegt werden. 
+Die Autorin zeigt, dass in Bezug auf das 
+habitualisierte Verhalten bei Teilnehmern 
+der ersten Welle bereits eine gewisse Verpflichtung 
+zur weiteren Teilnahme an der 
+zweiten Welle zu bestehen scheint, falls die 
+Teilnahme in der ersten Welle angenehm 
+verlief. Diese Erkenntnis kann zur Verbesserung 
+von Panelstudien ausgenutzt werden: 
+Möglicherweise sollte die erste Welle weniger 
+und angenehmere Fragen enthalten und 
+der Fragebogen in Folgewellen schrittweise 
+verlängert werden. Generell scheint die 
+Situation, in der sich Stichprobenmitglieder 
+zum konkreten Befragungszeitpunkt befinden, 
+eine weitaus bedeutendere Rolle für die 
+Teilnahmeentscheidung zu spielen als vorab 
+bekundete Teilnahmeintentionen. Für ein 
+4 Eine größere Analysestichprobe hätte man aber 
+eventuell erzielen können, wenn alle Probanden beide 
+Theorie-Komponenten beantwortet hätten.
+53 Rezensionen
+StepHan Büttner, 
+HanS-cHriStopH 
+HoBoHm, larS 
+müller (Hg.), 
+2011: Handbuch 
+Forschungsdaten-
+management. 
+Bock + Herchen 
+Verlag, Bad Honnef, 
+ISBN 978-3-88347-
+283-6, 24,90 EUR. 
+Online Version: 
+http://www.
+forschungsdaten-
+management.de/
+Man trifft immer wieder auf die teilweise 
+paradoxe Situation, dass die Vorteile und 
+Stärken wissenschaftlicher Methoden mit 
+nicht erbringbaren Leistungen legitimiert 
+werden oder dass zentrale Aspekte von Forschungsprozessen 
+kaum oder nur ungenügend 
+thematisiert werden, obwohl auf sie 
+beträchtliche Teile des wissenschaftlichen 
+Arbeitsprozesses entfallen. Beispielsweise 
+gehört es zum Kern des wissenschaftlichen 
+Selbstverständnisses, intersubjektiv zugängliche 
+und reproduzierbare Ergebnisse zu produzieren. 
+Aber ähnlich den Vergessenskurven 
+von Hermann Ebbinghaus gehen quer über 
+die verschiedenen Wissenschaftsfelder sehr 
+schnell die meisten relevanten Datenbestände 
+verloren. Wissenschaftliche Resultate 
+erweisen sich daher gerade nicht als intersubjektiv 
+zugänglich oder als reproduzierbar. 
+Ein anderer Punkt betrifft den Nutzen 
+wie den Vorteil von Sekundäranalysen sowie 
+das mit der Zeit wachsende Ergebnispotential 
+solcher Sekundäranalysen. Wegen der 
+vielfach unzugänglichen Daten wird auf 
+dieses Potential weitgehend verzichtet und 
+stattdessen auf jeweils neue Datenerhebungen 
+gesetzt, denen jeweils weitere neue 
+Datenerfassungen folgen. Die akkumulierten 
+Datenbestände aus der Vergangenheit, 
+obwohl sie aus kontextuellen oder aus langfristigen 
+Gesichtspunkten eine starke analytische 
+Bereicherung darstellen würden, 
+bleiben in ihrer überwiegenden Mehrzahl 
+besseres Verständnis sollten bei zukünftigen 
+Befragungen diese situativen Umstände 
+(Zeitpunkt, Haushaltskontexte, Stimmung, 
+Wetter, etc.) tatsächlich erhoben werden. 
+Diese Arbeit zeigt, dass für die Erforschung 
+von Nonresponse und Attrition noch ein 
+erhebliches Nachholpotential besteht. 
+Einige äußerst interessante Anregungen 
+werden von der Autorin am Beispiel einer 
+Onlineerhebung von Studierenden gegeben. 
+Es wäre zu begrüßen, wenn diese Anregungen 
+in weiterführenden Arbeiten aufgenommen 
+würden.
+Literatur
+AAPOR (The American Association for Public 
+Opinion Research) 2011: Standard Definitions: 
+Final Dispositions of Case Codes and Outcome 
+Rates for Surveys. 7th edition (6.3.2012).
+Ehling, M., U. Rendtel et al., 2003: CHINTEX (The 
+Change from Input Harmonisation to Ex-post 
+Harmonisation in National Samples of the 
+European Community Household Panel – Implications 
+on Data Quality) – Synopsis. http://
+www.destatis.de/jetspeed/portal/cms/Sites/des-
+tatis/Internet/DE/Content/Wissenschaftsforum/
+Chintex/ResearchResults/Downloads/Synopsis.
+psml (5.3.2012).
+Groves, R. und E. Peytcheva, 2008: The Impact of 
+Non-Response Rates on Non-Response Bias: 
+A Meta-Analysis. Public Opinion Quarterly 
+72 (2): 167-189.
+Lynn, P. und P. Clarke, 2002: Separating Refusal Bias 
+and Non-Contact Bias: Evidence from UK National 
+Surveys. The Statistician 51 (3): 319-333.
+Røed K., 2006: Longitudinal Administrative Registers 
+in Economic Research – A Norwegian Experience. 
+Unpublished Presentation for the Conference 
+on Longitudinal Surveys in International 
+Perspective, Montreal, 25-27 January 2006.
+Schouten, B., F. Cobben und J. Bethlehem, 2009: 
+Indicators for the Representativeness of Survey 
+Response. Survey Methodology 35 (1): 101-113.
+Voorpostel, M. und O. Lipps, 2011: Attrition in the 
+Swiss Household Panel: Is Change Associated 
+With Later Drop-Out? Journal of Official Statistics 
+27 (2): 301-318.
+oliver lippS, lauSanne
+* * * * *
+ 

--- a/src/test/resources/bibExtractor/test/35916.txt
+++ b/src/test/resources/bibExtractor/test/35916.txt
@@ -1,0 +1,253 @@
+www.ssoar.info
+Empirische Forschungen an sozial- und
+politikwissenschaftlichen Lehrstühlen in
+Deutschland, der Schweiz und Österreich 2008 bis
+2011
+Hackenbroch, Rolf
+Veröffentlichungsversion / Published Version
+Zeitschriftenartikel / journal article
+Zur Verfügung gestellt in Kooperation mit / provided in cooperation with:
+GESIS - Leibniz-Institut für Sozialwissenschaften
+Empfohlene Zitierung / Suggested Citation:
+Hackenbroch, Rolf: Empirische Forschungen an sozial- und politikwissenschaftlichen Lehrstühlen in Deutschland, der
+Schweiz und Österreich 2008 bis 2011. In: Methoden, Daten, Analysen (mda) 7 (2013), 1, pp. 123-128. URN: http://
+dx.doi.org/10.12758/mda.2013.005
+Nutzungsbedingungen:
+Dieser Text wird unter einer CC BY Lizenz (Namensnennung) zur
+Verfügung gestellt. Nähere Auskünfte zu den CC-Lizenzen finden
+Sie hier:
+http://creativecommons.org/licenses/
+Terms of use:
+This document is made available under a CC BY Licence
+(Attribution). For more Information see:
+http://creativecommons.org/licenses/
+DOI: 10.12758/mda.2013.005methoden, daten, analysen · Jg. 7(1), S. 123-128
+Rolf Hackenbroch
+Empirische Forschungen 
+an sozial- und 
+politikwissenschaft-
+lichen Lehrstühlen 
+in Deutschland, der 
+Schweiz und Österreich 
+2008 bis 2011
+Empirical Research at 
+Social and Political 
+Science Departments 
+in Germany, Austria 
+and Switzerland from 
+2008 to 2011
+Zusammenfassung
+Die vorliegende Studie gibt einen Überblick 
+über die in empirischen Forschungsprojekten 
+an sozial- und politikwissenschaftlichen 
+Lehrstühlen in den Jahren 2008 bis 2011 
+angewandten Methoden und deren Finanzierungsform. 
+Anhand der Befragung von 
+41 Universitätsprofessoren wird aufgewiesen, 
+dass Einstellungs- und Umfrageforschung 
+– und hier vor allem repräsentative 
+Bevölkerungsbefragungen – den weitaus 
+größten Anteil der Forschungsprojekte stellen. 
+Deren Finanzierung – dies im Unterschied 
+zu nicht umfragebasierten Methoden 
+– erfolgt vorwiegend über Drittmittel und 
+die Durchführung wird zum überwiegenden 
+Teil von externen Markforschungsinstituten 
+vorgenommen. Wie sich die Bedeutung 
+von externen Instituten in der universitären 
+Forschungslandschaft in Zukunft gestaltet, 
+bleibt abzuwarten, wird doch die methodische 
+Entwicklung in der empirischen Sozialforschung 
+stark im Bereich der OnlineForschung 
+gesehen. 
+Abstract
+The present study provides an overview of 
+the methods and the type of financing used 
+in empirical research projects at social and 
+political science departments in the years 
+2008 to 2011. Based on a survey of 41 chairs 
+it can be shown that survey research - and 
+especially representative surveys – provides 
+the largest share of the research projects. 
+Their funding - this in contrast to non-sur-veybased 
+methods - primarily uses thirdparty 
+funding and their implementation is 
+done for the most part by external market 
+research institutions. How the importance 
+of such external institutions in the university 
+research environment develops in the 
+future remains to be seen, but the methodological 
+development in empirical social 
+research is greatly seen in the field of online 
+research.
+© The Author(s) 2013. This is an Open Access article distributed under the terms of the 
+Creative Commons Attribution 3.0 License. Any further distribution of this work must 
+maintain attribution to the author(s) and the title of the work, journal citation and DOI.
+methoden, daten, analysen · Jg. 7(1), S. 123-128124 
+1 Ausgangspunkt und Zielsetzung1
+Von März bis Oktober 2011 führte die teleResearch GmbH aus Mannheim eine 
+Erhebung zu Umfang, Finanzierung und Methodik empirischer Forschungsprojekte 
+an sozial- und politikwissenschaftlichen Lehrstühlen durch. Die Untersuchung 
+bezog sich auf Deutschland, Österreich und die Schweiz und hatte alle empirischen 
+Primärerhebungen, die im Rahmen eines wissenschaftlichen Forschungsprojektes 
+zwischen 2008 und 2011 durchgeführt wurden, zum Gegenstand. Erhebungen im 
+Rahmen von Lehrveranstaltungen oder anderweitigen Projekten, die nicht in einen 
+Forschungsbericht oder eine wissenschaftliche Publikation mündeten, waren nicht 
+Gegenstand der Befragung. 
+Die Studie gibt einen Überblick über die in der universitären Forschung 
+angewandten Methoden und Ansätze. Sie untersucht, welche Bedeutung Bevölkerungsumfragen 
+im Vergleich zu Befragungen von Entscheidern in der Wirtschaft 
+und der öffentlichen Verwaltung haben und ob es in Abhängigkeit von den Methoden 
+verschiedene Finanzierungsformen und unterschiedliche Beteiligungen externer 
+Meinungsforschungsinstitute gibt. Darüber hinaus werden die methodischen 
+Schwerpunkte zukünftiger sozial- und politikwissenschaftlicher Forschungen aus 
+Sicht der befragten Lehrstuhlinhaber dargestellt. 
+2 Methodik der Studie
+Die Ausgangsstichprobe der Befragung bildeten 174 Adressen von Lehrstühlen 
+für Sozialwissenschaften und Politikwissenschaften an deutschsprachigen 
+Universitäten. Diese Adressen wurden in einem ersten Schritt danach 
+qualifiziert, ob die jeweiligen Lehrstühle generell im Bereich empirischer Sozialforschung 
+tätig sind. Es verblieben 93 Adressen, die das Ausgangssample für die 
+vorliegende Erhebung darstellten. Von diesen Adressen verblieben nach Kontaktaufnahme 
+und Qualifizierung der Zielperson 75 befragungsrelevante, verwertbare 
+Adressen (= Grundgesamtheit). Von diesen konnten insgesamt 41 Universitätsprofessoren 
+über ein ca. 12-15 minütiges telefonisches Interview zum 
+Forschungsgegenstand befragt werden. Mit einer Quote von 55% haben wir in 
+dieser schwer zu erreichenden Zielgruppe eine sehr gute Ausschöpfung erreicht.
+1 Unser Dank für entscheidende Impulse bei der Durchführung der Befragung und der 
+Fertigstellung der Auswertung gilt Herrn Gazmend Dika und Herrn Jens Schumm.
+125 Hackenbroch: Empirische Forschungen ... 
+Abbildung 1 Ausschöpfungsübersicht
+Ausgangsstichprobe (= Adressen insgesamt) n=174
+Ausgangssample Interviews (= verwendete Adressen von Lehrstühlen in D, A, CH n=93 100%
+Davon nicht zur Grundgesamtheit gehörend: n=18 19%
+  falsche Zielgruppe n=7
+  Befragungskriterien nicht erfüllt (keine wissenschaftlichen Forschungsprojekte 
+in den letzten drei Jahren) 
+n=13
+Grundgesamtheit (= abgeschlossene, verwertbare Adressen) n=75 100%
+Davon Ausfälle gesamt: n=34 45%
+  verweigert / kein Interesse / keine Zeit n=14
+  trotz bis zu 20-facher Kontaktversuche niemand erreichbar n=20
+Realisierte Interviews n=41 55%
+* z.B. ZP an Uni nicht aufgeführt; falsches Institut; Hauptarbeitsplatz nicht am Lehrstuhl
+3 Ergebnisse der Untersuchung
+3.1 Art der Primärerhebungen an sozial-/ politikwissenschaftlichen 
+ Lehrstühlen 2008-2011 
+Fast alle Lehrstühle, die empirische Primärerhebungen in den Jahren 2008 bis 2011 
+durchführten, haben Einstellungs- und Umfragedaten erhoben (36 von 41). Bei 
+zwei Dritteln dieser Lehrstühle wurden repräsentative Bevölkerungsbefragungen 
+und bei ca. 40% spezifische Zielgruppen der Bevölkerung befragt. Auffallend ist 
+insgesamt, dass Befragungen zu Zielgruppen in Wirtschaft und öffentlicher Verwaltung 
+nur bei 4 der befragten 41 Lehrstühle stattfanden. Der Schwerpunkt der 
+Erhebung von Einstellungs- und Umfragedaten liegt so eindeutig bei Bevölkerungsbefragungen 
+und nicht in der Analyse von Entscheidern in Wirtschaft und 
+öffentlicher Verwaltung. 
+Rund die Hälfte der befragten Universitätsprofessoren gab an, jenseits 
+von Einstellungs- und Umfragedaten auch empirische Forschungsprojekte mittels 
+anderer Methoden durchzuführen. Dabei wurde die Inhaltsanalyse als Erhebungsmethode 
+vor Gruppendiskussion und Experiment (Feld-, Laborexperiment) 
+genannt. Schaut man sich die absolute Anzahl der Studien an, so fällt die Vorrangstellung 
+von Einstellungs- und Umfragedaten (insgesamt 149 Studien) vor anderen 
+methodischen Ansätzen (56 Studien) sehr deutlich aus. 
+methoden, daten, analysen · Jg. 7(1), S. 123-128126 
+Besonders interessant ist, dass im Bereich von Einstellungs- und Umfragedaten 
+telefonische, Online-, persönliche und auch schriftliche Befragungen 
+gleichhäufig vertreten sind. Dominieren im Bereich der außeruniversitären Forschung 
+eindeutig telefonische und Online-Befragungen, so spielen im universitären 
+Bereich persönliche und schriftliche Befragungen eine große Rolle. 
+3.2 Finanzierung und Durchführung
+Finanziert werden die Primärerhebungen von Einstellungs- und Umfragedaten 
+größtenteils über Drittmittel von Forschungsförderungsinstitutionen (vier Fünftel 
+aller Lehrstühle), nur ein geringerer Teil wird ausschließlich oder zusätzlich aus 
+Eigenmitteln des Lehrstuhls/ des Instituts/ der Universität bzw. Drittmitteln anderer 
+Auftraggeber gefördert.
+Anders sieht das Bild bei der Finanzierung solcher Untersuchungen aus, 
+die mittels Inhaltsanalyse, Gruppendiskussionen oder Experimenten durchgeführt 
+werden. Diese erfolgt bei etwa der Hälfte der Lehrstühle über den eigenen Lehrstuhl/ 
+Institut/ Universität und nur etwa zu 50% über Drittmittel von Forschungsförderungsinstitutionen 
+bzw. Drittmittel anderer Auftraggeber. Die Finanzierung 
+über eigene Mittel spielt also vor allem bei diesen Methoden eine herausragende 
+Rolle; Einstellungs- und Umfragedaten werden hingegen schwerpunktmäßig über 
+die Finanzierung durch Drittmittel von Forschungsförderungsinstitutionen sichergestellt. 
+
+3.3 Einsatz externer Marktforschungsinstitute
+Eine der zentralen Fragen der vorliegenden Untersuchung war, in welchem Ausmaß 
+externe Marktforschungsinstitute mit Primärerhebungen seitens der Lehrstühle 
+betraut werden. Das Ergebnis ist überraschend eindeutig: Externe Marktforschungsinstitute 
+werden fast ausschließlich bei der Erhebung von Einstellungs- und 
+Umfragedaten beauftragt (23 von 36 Lehrstühlen beauftragten – teilweise neben 
+der Erhebung über den eigenen Lehrstuhl – externe Institute), bei anderen Methoden 
+wie Inhaltsanalyse, Experteninterviews und Gruppendiskussionen werden nur 
+äußerst selten externe Institute beauftragt (3 von 22 Lehrstühlen). Als Gründe 
+für die Beauftragung externer Markt- und Meinungsforschungsinstitute wird vor 
+allem auf den Arbeitsaufwand und auf ökonomische Gründe verwiesen. Ein Viertel 
+der befragten Lehrstühle nennen darüber hinaus die Kompetenz und Erfahrung 
+externer Institute als Grund für das Outsourcing.
+127 Hackenbroch: Empirische Forschungen ... 
+Die Motivation wiederum, Primärerhebungen am eigenen Lehrstuhl durchzuführen, 
+liegt neben niedrigeren Kosten vor allem darin, dass Erhebungen am 
+Lehrstuhl eine bessere Kontrolle der Erhebungen und eine bessere Handhabung der 
+Gesamtstudie gewährleisten. Besonders bei Primärerhebungen über Inhaltsanalysen, 
+Gruppendiskussionen und Experimente ist dies mit Abstand das am häufigsten 
+genannte Argument. 
+Und nach welchen Kriterien fiel nun die Entscheidung für ein bestimmtes 
+externes Marktforschungsinstitut? Hier steht die Reputation und Qualität des 
+Instituts eindeutig an erster Stelle, gefolgt von Kostengründen und guten Erfahrungen. 
+Dabei sind die Lehrstühle mit den Leistungen der Markt- bzw. Meinungsforschungsinstitute 
+im Durchschnitt durchaus zufrieden (Mittelwert 2,1 auf einer 
+Skala von 1 = sehr zufrieden bis 5 = überhaupt nicht zufrieden). Zur Zufriedenheit 
+trug sowohl die Umsetzung der Studienanforderungen als auch die gute Zusammenarbeit 
+bei. Kritik an den Leistungen der externen Institute wurde jedoch von 
+rund der Hälfte der Lehrstühle formuliert. Diese bezog sich auf die Kommunikation, 
+die Umsetzung der Methodik und auf die Ergebnisse an sich. 
+Im Vergleich zu den Erhebungen mit externen Instituten fällt die Zufriedenheit 
+mit Erhebungen am eigenen Lehrstuhl bzw. der Universität jedoch deutlich 
+höher aus (Mittelwert 1,5 bei Umfragedaten - 21 Lehrstühle; Mittelwert andere 
+Methoden 1,6 – 18 Lehrstühle). Die geäußerte Zufriedenheit bezog sich hier vor 
+allem auf die Ergebnisse selbst, aber auch auf die Kontrolle des Erhebungsprozesses 
+und den Ablauf der Studie. Jedoch auch etwa die Hälfte der Lehrstühle äußerte 
+Unzufriedenheit mit Erhebungen am eigenem Lehrstuhl bzw. der Universität. Diese 
+bezog sich auf die Methodik und die Ergebnisse, aber auch auf die Qualität der 
+Durchführung. 
+Wenn auch die Zufriedenheit mit den Erhebungen am eigenen Lehrstuhl 
+– vor allem auf Grund der besseren Kontrolle über den Ablauf und den Prozess – 
+größer ist, so zeigt sich doch auch hier, dass durchaus Mängel festgestellt wurden. 
+Trotzdem: Es erweist sich, dass bei der Forschungszusammenarbeit vor allem 
+eine engere Verzahnung zwischen den Vorgaben und Vorstellungen der Lehrstühle 
+und der Erhebung der Markt- und Meinungsforschungsinstitute notwendig ist. 
+4 Methodische Schwerpunkte zukünftiger Forschung
+„Wo liegt in der empirischen Sozialforschung in Zukunft der Schwerpunkt bei der 
+Anwendung der Methoden?“ Fast die Hälfte (18 Lehrstühle) nennen auf diese offen 
+gestellte Frage die Online-Forschung als eindeutigen Schwerpunkt. Dazu gehören 
+methoden, daten, analysen · Jg. 7(1), S. 123-128128 
+Online-Panels, webbasierte Befragungen oder einfach nur Online-Befragungen. 
+Weitere sechs Lehrstühle nennen die Kombination verschiedener Befragungs- und 
+Forschungsmethoden als zukünftigen Schwerpunkt der Methodenausrichtung und 
+weitere fünf Lehrstühle Panelstudien. Darüber hinaus gibt es noch eine Vielzahl an 
+Einzelnennungen, jedoch neben den genannten Punkten keine dezidierten weiteren 
+Schwerpunkte.
+Das Resümee hieraus: Online-Forschung ist auch in der universitären Forschung 
+als Methode bereits fest etabliert. Wie jedoch weiter oben gezeigt wurde, 
+ist die derzeitige Situation bei Primärerhebungen in der wissenschaftlichen Forschung 
+ganz stark durch das gleichzeitige Auftreten von schriftlichen, telefonischen, 
+persönlich-mündlichen und Online-Befragungen gekennzeichnet. Dies 
+findet seine Begründung nicht zuletzt darin, dass es sich bei einem Großteil der 
+Studien um repräsentative Bevölkerungsbefragungen handelt. 
+Insofern ist es interessant zu sehen, dass der übergroße Teil (34 Lehrstühle) 
+repräsentativen Bevölkerungsumfragen in Zukunft eine gleichbleibende oder sogar 
+noch zunehmende Rolle zuspricht. Begründet wird dies mit der gesellschaftlichen 
+Relevanz dieser Art von Querschnittserhebungen. Nur eine Minderheit von fünf 
+Lehrstuhlinhabern geht hingegen von einer in Zukunft sinkenden Bedeutung aus. 
+Deren Begründung liegt im zunehmenden Nonresponse-Problem und der damit 
+verbundenen erschwerten Durchführbarkeit solcher Studien. 
+Trotz der starken Stellung, die der Online-Forschung perspektivisch zugeschrieben 
+wird, werden repräsentative Bevölkerungsbefragungen - ob telefonisch, 
+schriftlich oder face-to-face – weiterhin ihre starke Bedeutung behalten. Wie sich 
+deren Stellenwert genau entwickelt, wird spannend bleiben zu beobachten. 
+ 
+Anschrift des Autors Rolf Hackenbroch
+ teleResearch GmbH 
+ D6, 5
+ 68159 Mannheim
+ E-Mail: hackenbroch@teleresearch.de 

--- a/src/test/resources/bibExtractor/test/37417.txt
+++ b/src/test/resources/bibExtractor/test/37417.txt
@@ -1,0 +1,1097 @@
+Diese Version ist zitierbar unter / This version is citable under:
+http://nbn-resolving.de/urn:nbn:de:0168-ssoar-374171
+www.ssoar.info
+BEFKI GC-K: eine Kurzskala zur Messung
+kristalliner Intelligenz
+Schipolowski, Stefan; Wilhelm, Oliver; Schroeders, Ulrich; Kovaleva,
+Anastassiya; Kemper, Christoph J.; Rammstedt, Beatrice
+Veröffentlichungsversion / Published Version
+Zur Verfügung gestellt in Kooperation mit / provided in cooperation with:
+GESIS - Leibniz-Institut für Sozialwissenschaften
+Empfohlene Zitierung / Suggested Citation:
+Schipolowski, Stefan ; Wilhelm, Oliver ; Schroeders, Ulrich ; Kovaleva, Anastassiya ; Kemper, Christoph J. ;
+Rammstedt, Beatrice: BEFKI GC-K: eine Kurzskala zur Messung kristalliner Intelligenz. In: Methoden, Daten, Analysen
+(mda) 7 (2013), 2, pp. 153-181. DOI: http://dx.doi.org/10.12758/mda.2013.010
+Nutzungsbedingungen:
+Dieser Text wird unter einer CC BY Lizenz (Namensnennung) zur
+Verfügung gestellt. Nähere Auskünfte zu den CC-Lizenzen finden
+Sie hier:
+http://creativecommons.org/licenses/
+Terms of use:
+This document is made available under a CC BY Licence
+(Attribution). For more Information see:
+http://creativecommons.org/licenses/
+DOI: 10.12758/mda.2013.010methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181
+Stefan Schipolowski, Oliver Wilhelm, Ulrich Schroeders, 
+Anastassiya Kovaleva, Christoph J. Kemper und 
+Beatrice Rammstedt
+BEFKI GC-K BEFKI GC-K 
+Zusammenfassung
+In aktuellen Intelligenzstrukturmodellen 
+gehört kristalline Intelligenz (gc) zu den 
+am besten etablierten Fähigkeitsfaktoren. 
+Dabei spiegelt gc die Einflüsse von Lernen 
+und Akkulturation wider und umfasst somit 
+alles Wissen, das Menschen im Laufe ihres 
+Lebens erwerben und zum Problemlösen 
+einsetzen. In diesem Beitrag beschreiben wir 
+die Entwicklung einer Kurzskala zur Messung 
+kristalliner Intelligenz mit fünfminütiger 
+Bearbeitungszeit, die auf deklarativen 
+Wissensfragen aus den Natur-, Geistes- und 
+Sozialwissenschaften beruht. Aus einem 
+umfangreichen Itempool wurde ein 32 Fragen 
+umfassender Wissenstest zusammengestellt 
+und einer bundesweit repräsentativen 
+Stichprobe von 1.134 Erwachsenen vorgelegt. 
+Anhand psychometrischer Kennwerte 
+und der Beziehungen zu Kovariaten erfolgte 
+eine Auswahl von 12 Items für die Kurzskala. 
+Ein eindimensionales Messmodell für diese 
+Itemauswahl wies eine gute Passung und 
+eine hohe Reliabilität des latenten Faktors 
+auf. In der Zielpopulation der erwachsenen 
+deutschen Bevölkerung wurden keine 
+substanziellen Boden- oder Deckeneffekte 
+Abstract
+Crystallized intelligence (gc) is a well-established 
+cognitive ability factor that has been 
+conceptualized as reflecting influences of 
+learning, education, and acculturation. In 
+this article, we describe the development 
+of a short knowledge scale for the measurement 
+of gc in five minutes administration 
+time using declarative knowledge 
+items from the sciences, the humanities, 
+and civics. Based on a large item pool we 
+compiled a 32-item knowledge test that 
+was subsequently presented to a nationally 
+representative sample of 1,134 German 
+adults. In the next step, this data were used 
+to derive a short 12-item knowledge scale. 
+A unidimensional measurement model had 
+satisfactory model fit and showed high reliability 
+of the latent factor. There were no 
+substantial floor or ceiling effects in the 
+adult German population. Similar to the 
+full scale, the short scale correlated highly 
+positively with education (ISCED-97) and 
+socio-economic status (ISEI) and was meaningfully 
+related to self-reported knowledge 
+and the Big Five personality traits. Therefore, 
+the short knowledge scale allows for 
+A Short Scale for the 
+Measurement of Crystallized 
+Intelligence
+Eine Kurzskala zur Messung 
+kristalliner Intelligenz
+© The Author(s) 2013. This is an Open Access article distributed under the terms of the 
+Creative Commons Attribution 3.0 License. Any further distribution of this work must 
+maintain attribution to the author(s) and the title of the work, journal citation and DOI.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181154 
+1 Einleitung1
+Die Messung psychologischer Merkmale wie kognitiver Fähigkeiten und Persönlichkeitseigenschaften 
+gewinnt in den Sozial- und Wirtschaftswissenschaften zunehmend 
+an Bedeutung (Rat für Sozial- und Wirtschaftsdaten 2010). So verweisen 
+etwa Grabner und Stern (2010) auf das komplexe, bisher jedoch nicht hinreichend 
+erforschte Zusammenspiel zwischen individuellen kognitiven Ressourcen und 
+sozioökonomischen Variablen. Auf Personenseite kommt hier neben der dekontextualisierten 
+Fähigkeit zum schlussfolgernden Denken bzw. dem Arbeitsgedächtnis 
+insbesondere jenen Fähigkeiten eine zentrale Rolle zu, die auf Lernen, Erfahrung 
+und Wissen beruhen und unter dem Begriff der kristallinen Intelligenz zusammengefasst 
+werden. Wiederholt wurde jedoch darauf hingewiesen, dass bislang nur 
+wenige für die Umfrageforschung geeignete, d.h. hinreichend kurze und effiziente 
+Messinstrumente zur Erfassung psychologischer Merkmale vorliegen (Rammstedt/
+Kemper/Klein/Beierlein/Kovaleva 2012; Lang/Weiss/Stocker/von Rosenbladt 2007).
+Der vorliegende Beitrag beschreibt die Entwicklung und Eigenschaften einer 
+Kurzskala zur Erfassung kristalliner Intelligenz anhand deklarativer Wissensfragen 
+in fünf Minuten Bearbeitungszeit. Die Datenbasis hierfür ist eine für die erwachsene 
+Wohnbevölkerung Deutschlands repräsentative Stichprobe, die dementsprechend 
+eine hohe Heterogenität bzgl. Alter und Bildung aufweist. Zuerst wird unter Rückgriff 
+auf einflussreiche Intelligenztheorien das Konstrukt der kristallinen Intelligenz 
+näher erläutert. Mit Blick auf die Validierung der Kurzskala folgt eine Darstellung 
+zentraler Befunde zu den Beziehungen zwischen kristalliner Intelligenz, relevanten 
+Personen- und Umweltmerkmalen sowie anderen psychologischen Konstrukten.
+1 Während der Erstellung dieses Beitrags war Stefan Schipolowski Fellow der International 
+Max Planck Research School „The Life Course: Evolutionary and Ontogenetic 
+Dynamics (LIFE)“.
+beobachtet. Übereinstimmend mit der 
+Langversion zeigten sich für die Kurzskala 
+hohe Beziehungen zum Bildungsabschluss 
+(ISCED-97) und sozioökonomischen Status 
+(ISEI) sowie erwartungskonforme Korrelationen 
+mit selbstberichtetem Wissen und den 
+fünf Hauptdimensionen der Persönlichkeit 
+(Big Five). Die Kurzskala ermöglicht folglich 
+eine effiziente, reliable und valide Erfassung 
+kristalliner Intelligenz im Rahmen der 
+Umfrageforschung.
+an efficient and valid measurement of crystallized 
+intelligence in survey research.
+155 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+1.1 Kristalline Intelligenz in konsensualen 
+Intelligenzstrukturtheorien
+Wissen und sprachliche Fähigkeiten spielen seit Beginn der psychometrischen 
+Intelligenzforschung im späten 19. Jahrhundert eine bedeutende Rolle in Intelligenztheorien. 
+So schlug Hermann Ebbinghaus bereits 1897 ein Verfahren zur „Prüfung 
+geistiger Fähigkeiten“ bei Schulkindern vor, das darauf beruhte, in kurzen 
+Texten unvollständige Wörter sinnhaft zu vervollständigen und charakterisierte 
+diese Anforderung explizit als „Intelligenzthätigkeit“ (Ebbinghaus 1897: 414). Für 
+Charles Spearman (1938) hingegen stellte non-verbales schlussfolgerndes Denken 
+den eigentlichen Kern allgemeiner Intelligenz, des sog. g-Faktors, dar. Nach Binet 
+und Simon (1905) sowie Hebb (1942) gehörte Cattell (1943) zu den ersten Intelligenzforschern, 
+die diese beiden Intelligenzaspekte aufgriffen und gegenüberstellten. 
+Statt eines einzigen Generalfaktors der Intelligenz postulierte Cattell zwei 
+bedeutende Faktoren, die er als fluide Intelligenz (gf) und kristalline Intelligenz (gc) 
+bezeichnete. Letztere zeigt sich nach Cattell (1971) in Leistungen, bei denen zuvor 
+erlernte Fertigkeiten und Wissen die entscheidende Rolle spielen. Typische Indikatoren 
+für gc bezeichnet Cattell als „schulische“ oder „akademische“ Tests, die auf 
+die Inhalte formaler Bildung abzielen. Damit übereinstimmend wurden in den Studien 
+in Cattells Labor (Cattell 1963; Horn/Cattell 1966; Cattell 1971) starke Ladungen 
+von sprachnahen Aufgaben und Wissenstests auf dem Faktor gc berichtet (vgl. 
+etwa Horn 1965). Aus Cattells theoretischen Schriften geht hervor, dass gc die 
+Gesamtheit des Wissens umfasst, das Menschen im Laufe ihres Lebens erwerben 
+und zum Problemlösen einsetzen. Aufgrund der mit steigendem Lebensalter zunehmenden 
+Spezialisierung in Form unterschiedlicher Berufswahlen, verschiedenartiger 
+Freizeitaktivitäten und Interessen würde eine umfassende Messung kristalliner 
+Intelligenz im Erwachsenenalter demnach eine nahezu unendliche Vielfalt an 
+Iteminhalten erfordern. Übereinstimmend betont auch Horn (1988) die Breite des 
+gc-Konstrukts und seine Nähe zum Generalfaktor der Intelligenz. In seiner Auflistung 
+typischer Indikatoren spielen verbale Fähigkeiten eine prominente Rolle (z.B. 
+„verbal knowledge“) sowie Wissen in einer Vielzahl von Bereichen („information 
+about the humanities, social and physical sciences, business and culture in general“; 
+Horn 1988: 659). Horn und Noll (1997: 69) beschreiben kristalline Intelligenz 
+dementsprechend als „akkulturiertes Wissen“, das über Aufgaben gemessen wird, 
+die „Tiefe und Breite des Wissens der dominanten Kultur“ widerspiegeln.
+Als weiteres einflussreiches Intelligenzmodell soll Carrolls (1993) Drei-Stra-tumTheorie 
+erwähnt werden, die nach wie vor als Status Quo der Intelligenzforschung 
+gilt. Das Modell basiert auf der Reanalyse von mehr als 460 Datensätzen zu 
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181156 
+kognitiven Fähigkeitskonstrukten und beschreibt verschiedene Schichten („Strata“) 
+mit Intelligenzfaktoren unterschiedlicher Breite. Zu den insgesamt acht Faktoren 
+auf Stratum II gehören auch gf und gc. Ähnlich wie Cattell betont auch Carroll mit 
+Blick auf den gc-Faktor die Rolle von Erfahrung, Lernen und Akkulturation, verschiebt 
+jedoch die Definition von gc in Richtung sprachlicher Fähigkeiten wie Leseverstehen 
+und Fremdsprachenkenntnissen (Carroll 1993: 626). Allerdings dokumentiert 
+Carroll auch die hohen Ladungen von Wissenstests auf dem gc-Faktor. Eine 
+besondere Bedeutung kommt dem Stratum-I-Faktor „General Information“ zu, der 
+Unterschiede im Erwerb von Wissen jenseits von Sprachkenntnissen widerspiegelt 
+(vgl. K0; Carroll 1993: 590 bzw. 634). Dieser Wissensfaktor gehört zu jenen Faktoren, 
+die in Carrolls Reanalysen häufig die höchste oder zweithöchste Ladung auf 
+einem übergeordneten gc-Faktor aufwiesen (vgl. auch Carroll 2003). In Übereinstimmung 
+mit den theoretischen Vorarbeiten Cattells untermauern diese Befunde 
+die Position, dass eine Operationalisierung kristalliner Intelligenz im Erwachsenenalter 
+Wissen aus möglichst vielen unterschiedlichen Bereichen berücksichtigen 
+sollte.
+1.2 Alters- und Geschlechtsunterschiede in kristalliner Intelligenz
+Das Konzept der kristallinen Intelligenz wurde auch von Seiten der Entwicklungspsychologie 
+über die Lebenspanne aufgegriffen (vgl. etwa Baltes 1987; Baltes/Staudinger/Lindenberger 
+1999), die wesentliche Erkenntnisse zum Entwicklungsverlauf 
+von gc liefern konnte. Nach Baltes et al. (1999: 486ff) zeigt die kristalline Pragmatik 
+der Kognition, die kulturell vermitteltes Wissen repräsentiert, einen deutlichen 
+Anstieg im Kindes- und Jugendalter, bleibt im Verlauf des Erwachsenenalters weitgehend 
+stabil und nimmt erst im sehr hohen Lebensalter ab. Auch Ackerman (2008) 
+argumentiert in seinem Literaturüberblick, dass sich gc im Sinne von Allgemeinwissen 
+und lexikalischem Wissen durch hohe Stabilität im Erwachsenenalter auszeichnet. 
+Ein anderes Bild ergibt sich jedoch für spezialisiertes, bereichsspezifisches 
+Wissen im Sinne von Expertise. So konnten Ackerman und Kollegen in mehreren 
+Studien zeigen, dass im Erwachsenenalter teilweise deutliche Leistungszuwächse 
+im bereichsspezifischen Wissen zu beobachten sind (Ackerman 2000; Ackerman/
+Rolfhus 1999; zusammenfassend Ackerman/Beier 2004). Diese Befunde illustrieren, 
+dass die Beziehung kristalliner Intelligenz zum Alter auch von den gemessenen 
+Inhalten abhängig ist. Wird gc über das im Kindes- und Jugendalter erworbene 
+schulische Wissen gemessen, das unabhängig vom Lebensalter häufig abgerufen 
+wird – wie es etwa für lexikalisches Wissen der Fall ist – sind kaum Veränderungen 
+im Erwachsenalter zu beobachten; wird gc hingegen als Expertise operationalisiert, 
+157 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+die erst durch eine spezielle Ausbildung oder durch die Berufsausübung erworben 
+wird, können auch im mittleren Erwachsenenalter substanzielle Zuwächse beobachtet 
+werden.
+Verschiedene Arbeiten aus der psychologischen Forschung haben sich mit 
+Geschlechtsunterschieden in Wissensleistungen auseinandergesetzt. Hier sind insbesondere 
+die Arbeiten von Lynn sowie aus der Arbeitsgruppe von Ackerman zu 
+erwähnen. In Untersuchungen an Jugendlichen bzw. jungen Erwachsenen mit einer 
+viele Wissensbereiche umfassenden Testbatterie wurde wiederholt ein Leistungsvorsprung 
+im Allgemeinwissen zugunsten der Männer von etwa einer halben Standardabweichung 
+gefunden (d = 0.50 bis 0.60; Lynn/Irwing/Cammock 2001; Lynn/
+Irwing 2002; Lynn/Wilberg/Margraf-Stiksrud 2004). Ähnliche Ergebnisse berichten 
+Ackerman, Bowen, Beier und Kanfer (2001), die eine Stichprobe von 320 Studierenden 
+mit einer breit angelegten Wissenstestbatterie zu 19 spezifischen Wissensbereichen 
+untersuchten. In 14 der 19 Wissensbereiche erzielten Männer signifikant 
+bessere Ergebnisse, insbesondere in den naturwissenschaftlich-technischen und 
+einigen sozialwissenschaftlichen Bereichen. Für keinen Wissensbereich ergaben 
+sich signifikant bessere Resultate für Frauen; in vier Bereichen fanden sich keine 
+oder sehr geringe Unterschiede. Insgesamt ergab sich für einen zusammengesetzten 
+Gesamtwert zum deklarativen Wissen ein Unterschied von d = 0.68 zugunsten 
+der Männer. Einschränkend muss jedoch gesagt werden, dass diese geschlechtsbezogenen 
+Disparitäten kulturspezifisch sind und nicht auf andere Kulturen übertragbar 
+sein müssen.
+1.3 Zusammenhänge kristalliner Intelligenz mit Bildung und 
+Lernumwelt
+Wie oben ausgeführt, ist die Abhängigkeit kristalliner Intelligenz von Lernen und 
+Bildung das zentrale Definitionsmerkmal des Konstrukts. Aufgrund der Langfristigkeit 
+des Wissenserwerbs und dessen Abhängigkeit von den zur Verfügung stehenden 
+Lerngelegenheiten und -ressourcen sind folglich hohe Zusammenhänge 
+zwischen gc und der Qualität und Quantität formaler Bildung zu erwarten, wie 
+sie in formalen Bildungsabschlüssen und darauf beruhenden Indizes zum Ausdruck 
+kommen (Cliffordson/Gustafsson 2008; Ceci 1991). Ebenso kann eine substanzielle 
+positive Korrelation mit solchen Indikatoren und Indizes angenommen werden, die 
+für den Wissenserwerb bedeutsame Ressourcen erfassen (Rowe/Jacobson/van den 
+Oord 1999). Dies betrifft Maße des sozioökonomischen Status ebenso wie Fragen 
+nach der Ausstattung des Haushalts, etwa zur Anzahl der verfügbaren Bücher 
+(Ehmke/Siegle 2005).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181158 
+1.4 Zusammenhänge kristalliner Intelligenz mit Selbsteinschätzungen 
+des Wissens und Persönlichkeitskonstrukten
+Neben einer Testung deklarativen Wissens über Wissensfragen mit mehreren Antwortalternativen, 
+die eindeutig als richtig oder falsch zu werten sind, können auch 
+Selbstberichte herangezogen werden. Derartige Selbsteinschätzungen des eigenen 
+Wissens spiegeln jedoch neben der tatsächlichen Fähigkeitsausprägung weitere 
+Varianzquellen wider (z.B. faking-good), so dass Selbsteinschätzungen des Wissens 
+und objektive Wissenstests als unterschiedliche, wenngleich korrelierte Konstrukte 
+aufzufassen sind (Furnham/Dissou 2007). Die Korrelationen zwischen entsprechenden 
+Messungen sind somit zwar substanziell, fallen aber selbst unter Verwendung 
+von Ansätzen zur Korrektur von Antwortverzerrungen deutlich niedriger aus als 
+zwischen Messungen desselben Konstrukts (Hülür/Wilhelm/Schipolowski 2011; 
+Rolfhus/Ackerman 1996; Paulhus/Harms 2004).
+Eine Vielzahl an Studien hat sich mit den Zusammenhängen zwischen kognitiven 
+Fähigkeiten einerseits und Persönlichkeitseigenschaften im Sinne typischen 
+Verhaltens (Cronbach 1949) andererseits befasst. Hervorzuheben ist die Metaanalyse 
+von Ackerman und Heggestad (1997), die anhand von 135 Studien die 
+Beziehungen zwischen Persönlichkeits- und Fähigkeitskonstrukten beleuchtet. Die 
+Autoren beschränken sich auf der Fähigkeitsseite nicht auf die Betrachtung allgemeiner 
+Intelligenz, sondern differenzieren zwischen zehn verschiedenen Fähigkeitskonstrukten, 
+darunter kristalline Intelligenz und eine zusammengefasste Kategorie 
+Wissen/Achievement. Bei der Kategorisierung der gemessenen Konstrukte 
+orientieren sich die Autoren an den Charakterisierungen der Fähigkeitsfaktoren bei 
+Carroll (1993). Kristalline Intelligenz umfasst demnach sprachliche Leistungen und 
+Allgemeinwissen (vgl. Carroll 1993: 599); zur Kategorie Wissen/Achievement zählen 
+neben spezifischen Wissenstests auch Fachleistungstests etwa im Schulfach Biologie 
+(vgl. Carroll 1993: 513). Die Persönlichkeitsskalen der Studien wurden anhand 
+verschiedener in der Forschung etablierter Systeme klassifiziert, darunter das 
+Modell der fünf Hauptdimensionen der Persönlichkeit (Big Five; für ausführliche 
+Beschreibungen dieser Dimensionen siehe Ostendorf/Angleitner 2004). Die metaanalytische 
+Betrachtung der korrelativen Zusammenhänge zwischen den Big FiveFaktoren 
+und gc bzw. Wissen/Achievement ergab jeweils die mit Abstand höchsten 
+Beziehungen für Offenheit. Hier wurde eine minderungskorrigierte Korrelation von 
+.30 (gc) bzw. .28 (Wissen/Achievement) ermittelt. Eine ebenfalls positive, aber mit 
+.11 deutlich niedrigere Korrelation zeigte sich zwischen gc und Extraversion. Für 
+Wissen/Achievement lag diese bei .05 und war nicht signifikant von null verschieden. 
+Negative Zusammenhänge wurden hingegen mit Neurotizismus (Korrelationen 
+159 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+von -.09 mit gc und -.13 mit Wissen/Achievement) und Gewissenhaftigkeit gefunden, 
+wobei die Korrelation zwischen Gewissenhaftigkeit und gc nicht signifikant 
+war und für Wissen/Achievement mit -.19 zwar vom Betrag her höher ausfiel, diese 
+Angabe jedoch nur auf einer einzigen Studie mit relativ geringer Fallzahl basiert. 
+Die Korrelationen mit Verträglichkeit waren nicht signifikant von null verschieden. 
+Die vergleichsweise hohe Beziehung zwischen gc bzw. Wissen/Achievement 
+und Offenheit ist sowohl empirisch gut belegt (von Stumm/Ackerman 2012) als 
+auch aus theoretischer Perspektive plausibel. So zielen Items zur Messung von 
+Offenheit unter anderem auf intellektuelle Neugier, das Bestreben, neues Wissen 
+zu erwerben und auf kulturelles Engagement (Ostendorf/Angleitner 2004). Folgerichtig 
+beschreibt Ackerman (1996) neben „typischem intellektuellem Engagement 
+(TIE)“ Offenheit als Persönlichkeitskonstrukt mit den höchsten Beziehungen zu gc 
+und geisteswissenschaftlichem Wissen. Übereinstimmend argumentieren Ziegler, 
+Danay, Heene, Asendorpf und Bühner (2012), dass Personen mit hohen Offenheitswerten 
+mehr Zeit in Lernen und Wissenserwerb investieren.
+1.5 Zusammenfassung und erwartete Zusammenhänge
+Aus theoretischen und diagnostischen Überlegungen heraus sollte eine Operationalisierung 
+von gc über deklaratives Wissen aus möglichst vielen verschiedenen 
+Wissensbereichen erfolgen. Zu erwarten sind hohe positive Korrelationen zwischen 
+kristalliner Intelligenz und der Qualität und Quantität formaler Bildung sowie mit 
+Indikatoren, die für den Wissenserwerb bedeutsame Ressourcen erfassen, wie beispielsweise 
+Maße des sozioökonomischen Status. Mit Blick auf Altersunterschiede 
+ist in der Erwachsenenpopulation aufgrund der hohen Stabilität kristalliner Intelligenz 
+von sehr geringen Effekten auszugehen, sofern die gemessenen Inhalte auf 
+solche Wissensbestände abzielen, die in einer Vielzahl von Lernumwelten erworben 
+werden können. In Anlehnung an die in der Literatur beschriebenen geschlechtsbezogenen 
+Unterschiede in Wissensleistungen wird ein Vorsprung der Männer von 
+etwa einer halben Standardabweichung bis zwei Drittel einer Standardabweichung 
+erwartet. Des Weiteren ist von positiven Korrelationen von gc mit selbsteingeschätztem 
+Wissen sowie mit dem Persönlichkeitsfaktor Offenheit auszugehen.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181160 
+2 Methode
+2.1 Stichprobe
+Als Grundgesamtheit für die Stichprobenziehung wurde die Wohnbevölkerung der 
+Bundesrepublik Deutschland im Alter von 18 Jahren und älter definiert. Es wurden 
+auch Personen mit Zuwanderungshintergrund berücksichtigt, sofern sie die 
+deutschsprachigen Fragen und Aufgaben verstehen und auf Deutsch antworten 
+konnten. Die Stichprobe wurde mithilfe des ADM-Stichprobensystems F2F der 
+Arbeitsgemeinschaft deutscher Marktforschungsinstitute gezogen. Dabei handelt 
+es sich um ein komplexes mehrstufiges Ziehungsverfahren, in dem zunächst Flächen, 
+dann Privathaushalte und schließlich Zielpersonen innerhalb der Haushalte 
+nach einem Zufallsverfahren ausgewählt werden (für Details vgl. von der Heyde 
+2009). Nach diesem Verfahren wurde eine Stichprobe von 1206 Personen realisiert, 
+die an der Erhebung teilnahmen. Im Anschluss wurden auf Basis des Zensus von 
+GESIS Fallgewichte erstellt, um Repräsentativität für die o.g. Grundgesamtheit mit 
+Blick auf Region (Ost- bzw. Westdeutschland), Geschlecht, Bildung und Alter zu 
+gewährleisten. Grundlage der Gewichtung war ein reduzierter Datensatz von 1.134 
+Fällen nach Ausschluss unbrauchbarer Datenpunkte sowie von Personen ohne 
+deutsche Staatsbürgerschaft, um für die Gewichtung eine eindeutige Definition 
+der Grundgesamtheit zu ermöglichen. Die gewichtete Stichprobe umfasst somit 
+1.134 Erwachsene (52,2% weiblich) im Alter von 18 bis 93 Jahren (M = 52 Jahre, 
+SD = 18 Jahre) aus dem gesamten Bundesgebiet.
+2.2 Messinstrumente
+In einem umfangreichen Fragebogen wurden verschiedene soziodemographische 
+Merkmale der Teilnehmerinnen und Teilnehmer erfasst. Hierzu zählten Geburtsjahr 
+und -monat, Geschlecht, Familienstand, Staatsangehörigkeit, erreichter bzw. 
+(bei Schülerinnen und Schülern) angestrebter allgemeinbildender Schulabschluss, 
+beruflicher Ausbildungsabschluss, Erwerbsstatus, berufliche Stellung und Haushaltsnettoeinkommen. 
+Die Erfassung dieser Merkmale orientierte sich an den 
+Demographischen Standards des Statistischen Bundesamtes (2010). Ergänzend 
+wurde anhand von sieben Kategorien die Anzahl der Bücher im Elternhaus erfragt, 
+das Geburtsland sowie die berufliche Stellung der Eltern, als der/die Teilnehmende 
+15 Jahre alt war. Anhand zweier fünfstufiger Skalen wurden vom Interviewer die 
+Deutschkenntnisse und die soziale Schichtzugehörigkeit der Teilnehmenden eingeschätzt.161 
+Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Zur Messung kristalliner Intelligenz wurde auf den umfangreichen Itempool 
+des BEFKI-Projekts (Berliner Test zur Erfassung Fluider und Kristalliner Intelligenz; 
+Wilhelm/Schroeders/Schipolowski, in Vorbereitung; Wilhelm/Schipolowski 
+2010) zurückgegriffen, mit dem deklaratives Wissen in 16 verschiedenen Domänen 
+erfasst werden kann. Im Einzelnen wird naturwissenschaftliches (Physik, Chemie, 
+Biologie, Medizin, Geografie, Technologie), geisteswissenschaftliches (Literatur, 
+Kunst, Musik, Religion, Philosophie) und sozialwissenschaftliches Wissen erfragt 
+(Geschichte, Recht, Politik, Wirtschaft, Finanzen). Die Auswahl der Wissensbereiche 
+orientierte sich an der empirisch begründeten Klassifikation von Ackerman (2000; 
+Rolfhus/Ackerman 1999). Für die aktuelle Studie wurden insgesamt 32 Wissensitems 
+anhand inhaltlicher und psychometrischer Kriterien aus dem Gesamtitempool 
+ausgewählt. Konkret wurden zwei Items aus jedem der 16 Wissensbereiche 
+eingesetzt, wobei eines der beiden Items zu jedem Bereich von geringer bis mittlerer 
+Schwierigkeit war (entwickelt für Personen ohne Schulabschluss, mit Haupt-schul 
+oder Mittlerem Schulabschluss), das andere von hoher Schwierigkeit (entwickelt 
+für Personen, die über die Hochschulreife verfügen bzw. diese anstreben). 
+Die psychometrische Eignung der Items wurde anhand von Vorinformationen aus 
+verschiedenen Erhebungen sichergestellt (Schipolowski/Schroeders/Wilhelm 2008; 
+Schroeders/Schipolowski/Wilhelm 2010; Schroeders/Schipolowski/Nelles/Wilhelm 
+2011). Ausschlaggebend war dabei neben den Informationen zur Itemschwierigkeit 
+insbesondere eine hohe positive Trennschärfe in den genannten Voruntersuchungen. 
+Alle Wissensitems waren ausschließlich textbasiert und hatten ein Multiple-ChoiceFormat 
+mit vier Antwortalternativen, von denen genau eine die richtige 
+Lösung darstellte.
+Zusätzlich zur kristallinen Intelligenz wurden weitere psychologische Konstrukte 
+erfasst. Der BFI-10 (Rammstedt/John 2007) ermöglichte die Erfassung der 
+Big-Five-Persönlichkeitsdimensionen Neurotizismus (N), Extraversion (E), Offenheit 
+(O), Verträglichkeit (V) und Gewissenhaftigkeit (G) anhand von jeweils zwei (N, E, O, 
+G) bzw. drei Items (V). Die Items bestanden aus Aussagen, deren Zutreffen von den 
+Teilnehmenden auf einer fünfstufigen Ratingskala eingeschätzt wurde. Mit dem 
+VOC-T (Ziegler/Kemper/Rammstedt 2013) wurde zudem ein Maß für die Selbsteinschätzung 
+des eigenen Wissens eingesetzt. Zu insgesamt 12 verschiedenen Begriffen 
+aus den Natur-, Geistes- und Sozialwissenschaften sowie dem handwerklichen 
+Bereich gaben die teilnehmenden Personen anhand einer siebenstufigen Ratingskala 
+an, wie vertraut sie mit dem jeweiligen Begriff oder Konzept sind. Neben diesen 
+real existierenden Begriffen enthält der VOC-T zusätzlich drei fiktive Begriffe.
+Weitere eingesetzte Skalen dienten der Erfassung von Lebenszufriedenheit, 
+politischer Partizipation, Werten, Kontrollüberzeugungen, Selbstwirksamkeitsermethoden, 
+daten, analysen · 2013, Jg. 7(2), S. 153-181162 
+wartungen, Impulsivität und dem Gesundheitszustand. Da diese Skalen nur in das 
+Imputations-, nicht jedoch in das Analysemodell einbezogen wurden, werden sie 
+hier nicht näher beschrieben.
+2.3 Durchführung
+Die Erhebung der Daten erfolgte im Zeitraum 2. Mai bis 23. Juni 2011 durch ein 
+beauftragtes Erhebungsinstitut. Geschulte Interviewer suchten die Studienteilnehmerinnen 
+und -teilnehmer zu vorab vereinbarten Terminen in ihren Wohnungen 
+auf, um die Befragung bzw. Testung durchzuführen. Die soziodemographischen 
+Angaben und die Antworten auf die Persönlichkeitsitems wurden vom Interviewer 
+erfragt und in eine Eingabemaske am Notebook eingegeben (CAPI, computer 
+assisted personal interview). Den gc-Test bearbeiteten die Teilnehmenden selbstständig 
+am Notebook (CASI, computer assisted self-interview). In beiden Fällen war 
+die Abfolge der Fragen durch ein Skript vorgegeben, um einen standardisierten 
+Ablauf zu gewährleisten. Beim gc-Test wurden immer vier Fragen gleichzeitig auf 
+dem Bildschirm dargestellt; um zur nächsten Bildschirmseite zu gelangen, musste 
+die teilnehmende Person zunächst alle vier Fragen der aktuellen Seite beantworten 
+(ggf. durch Raten). Für die Bearbeitung der 32 gc-Items war ein Zeitlimit von 10 
+Minuten vorgegeben. Bei Erreichen des Zeitlimits brach der Wissenstest automatisch 
+ab und es wurde mit dem nächsten Fragenkomplex fortgefahren. Die Dauer 
+des gesamten Interviews betrug im Durchschnitt 43 Minuten (SD = 13).
+2.4 Datenaufbereitung und Auswertungsverfahren
+Zur Aufbereitung der gewichteten Stichprobendaten wurden im ersten Schritt 
+anhand der vorliegenden demographischen Angaben verschiedene Indizes gebildet. 
+Als Index zur formalen Bildung wurde die ISCED-97 (International Standard Classification 
+of Education; UNESCO 1997) genutzt. Dabei wurden die Angaben zum 
+höchsten erreichten Schulabschluss sowie zum Ausbildungsabschluss in einer ordinalskalierten 
+Variable mit 6 Stufen zusammengeführt (vgl. Statistisches Bundesamt 
+2010: 79). Auf der niedrigsten Stufe (ISCED 1) befinden sich demnach Personen 
+ohne Schul- und Ausbildungsabschluss, während die höchste Stufe (ISCED 6) mit 
+Personen besetzt ist, die die allgemeine oder Fachhochschulreife besitzen und nach 
+erfolgreichem Hoch- bzw. Fachhochschulabschluss zusätzlich einen weiterführenden 
+akademischen Grad (Promotion) erlangt haben. Als Index des sozioökonomischen 
+Status wurde der ISEI (International Socio-Economic Index of Occupational 
+Status; Ganzeboom/De Graaf/Treiman 1992) verwendet. Der ISEI beruht auf Anga163 
+Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+ben zur Berufstätigkeit und der Prämisse, dass diese Informationswert bezüglich 
+Einkommen und Bildung besitzt, die wiederum „die Hauptquellen der Macht in 
+modernen Gesellschaften“ sind (Ganzeboom et al. 1992: 9). Konkret werden einzelnen 
+Berufen Statuswerte zugeordnet, die auf internationalen Daten zum Einkommen 
+und zur Bildung beruhen, über die Ausübende dieser Berufstätigkeiten typischerweise 
+verfügen. Auf dieser Basis ergibt sich eine Skala von 16 (niedriger Status; 
+etwa Reinigungskräfte) bis 90 (hoher Status; Richter). Ein Weg zur Ermittlung der 
+ISEI-Werte ist die Kodierung von Berufstätigkeiten nach der ISCO (International 
+Standard Classification of Occupations; ILO 2007). Im vorliegenden Fall wurde ein 
+weniger aufwändiges Vorgehen gewählt, das auf Angaben zur beruflichen Stellung 
+beruht, von der nach Wolf (1995) ebenfalls auf den ISEI geschlossen werden 
+kann (vgl. Statistisches Bundesamt 2010). Nach diesem Vorgehen ergibt sich für die 
+aktuelle Studie eine vereinfachte ISEI-Skala mit 13 verschiedenen Ausprägungen. 
+Die Bildung des ISEI wurde für die Teilnehmenden selbst sowie für deren Eltern 
+durchgeführt; in letzterem Fall wird für die folgenden Analysen der höchste der 
+beiden elterlichen ISEI-Werte (HISEI) verwendet. Das Haushaltsnettoeinkommen 
+wurde auch direkt erfragt, wobei zum Teil Freitextantworten, überwiegend jedoch 
+Angaben in Form von Einkommenskategorien vorlagen. Freitextanworten wurden 
+auf die vorliegenden 24 Kategorien rekodiert, um ein einheitliches Antwortformat 
+zu erhalten.
+Für die Skalen zu den psychologischen Konstrukten wurden Summen- oder 
+Mittelwerte so gebildet, wie dies von den Autoren der jeweiligen Instrumente vorgeschlagen 
+wurde. Somit lag für die folgenden Analysen jeweils ein Wert für jede 
+der fünf Big-Five-Dimensionen vor. Als Indikator des selbstberichteten Wissens 
+wurde ein Gesamtwert über alle 12 Items des VOC-T genutzt, die sich auf real existierende 
+Begriffe beziehen; die fiktiven Begriffe wurden nicht einbezogen2. 
+Die Items zur Messung der kristallinen Intelligenz wurden zunächst in richtig 
+versus falsch beantwortet rekodiert. Anschließend wurde ein Summenwert über 
+alle 32 Items als Schätzer der Personenfähigkeit auf der Gesamtskala berechnet. 
+Auf Basis der 32 Wissensitems der Gesamtskala erfolgte im nächsten Schritt die 
+Itemselektion für die Kurzskala nach folgenden Kriterien:
+  Um einen flexiblen Einsatz der Kurzskala in der Umfrageforschung zu ermöglichen, 
+sollte deren Bearbeitungszeit bei 5 Minuten liegen. Dies entspricht der 
+geschätzten Bearbeitungszeit von 12 Items.
+2 Die fiktiven Begriffe des VOC-T, engl. foils, können zur Berechnung weiterer Kennwerte 
+herangezogen werden, die jedoch im vorliegenden Beitrag nicht berücksichtigt werden.methoden, 
+daten, analysen · 2013, Jg. 7(2), S. 153-181164 
+  Zur bestmöglichen Erhaltung der inhaltlichen Breite der Wissensmessung sollte 
+einerseits die Dreiteilung in natur-, geistes- und sozialwissenschaftliches Wissen 
+beibehalten werden, andererseits sollten möglichst viele der 16 Wissensbereiche 
+der Gesamtskala auch in der Kurzskala enthalten sein.
+  Um Boden- und Deckeneffekte zu minimieren, sollten die ausgewählten Items 
+einen großen Schwierigkeitsbereich abdecken. Die relative Lösungshäufigkeit 
+sollte jedoch stets oberhalb der Ratewahrscheinlichkeit von .25 liegen.
+  Es wurde ein einfaktorielles Messmodell mit guter Modellpassung und Itemladungen 
+(Trennschärfen) von .50 oder höher angestrebt. In keinem Fall sollten 
+Ladungen < .30 auftreten.
+  Die Kurzskala sollte ähnliche Beziehungen zu Personen- und Umweltmerkmalen 
+sowie anderen psychologischen Konstrukten aufweisen wie die Gesamtskala.
+Nach erfolgter Itemselektion wurde für die Kurzskala mit 12 Items ebenfalls ein 
+Summenwert berechnet. 
+Um Einschränkungen bei der Teststärke sowie Verzerrungen durch nicht 
+zufällig fehlende Informationen3 zu minimieren, wurden fehlende Datenpunkte im 
+Wissenstest sowie in allen Kovariaten imputiert (Lüdtke/Robitzsch/Trautwein/Köller 
+2007). Der Anteil fehlender Werte bei den 32 Wissensitems betrug im Mittel pro 
+Item 5.8% (SD = 7.0%, Spannweite 0.4% bis 20.8%); die vorliegenden Fallzahlen 
+für die Kovariaten gehen aus der Ergebnistabelle hervor (vgl. Tabelle 4, Spalte Nvi). 
+Speziell bei den Wissensitems, für die Datenpunkte fast ausschließlich aufgrund der 
+Zeitbegrenzung fehlten, ermöglichte die Imputation eine Minimierung konstruktirrelevanter 
+Varianz (etwa interindividuelle Unterschiede in mentaler Geschwindigkeit; 
+Danthiir/Roberts/Schulze/Wilhelm 2004). Konkret wurde das Verfahren der 
+multiplen Imputation mit 100 Replikationen genutzt (Graham/Olchowski/Gilreath 
+2007). Um die fehlenden Werte möglichst zuverlässig schätzen zu können, wurden 
+alle verfügbaren Kovariaten, also Personen- und Umweltmerkmale sowie psychologische 
+Konstrukte, in das Imputationsmodell einbezogen (Collins/Schafer/Kam 
+2001). Die im Ergebnisteil berichteten Statistiken und Koeffizienten sind Mittelwerte 
+über alle Replikationen. Bei der Ermittlung von Standardfehlern wurde die 
+Streuung zwischen den Replikationen berücksichtigt.
+Zur Berechnung von Kovarianzen bzw. Korrelationen kamen Verfahren 
+zum Einsatz, die dem Skalenniveau der einbezogenen Variablen Rechnung tragen. 
+3 Als „nicht zufällig fehlende Informationen“ sind solche Ausfälle zu betrachten, die von 
+der Ausprägung der fraglichen Variable selbst und/oder anderen beobachteten Variablen 
+abhängig sind; vgl. die Definition von Missing Not At Random (MNAR) und Missing 
+At Random (MAR) bei Rubin (1976).
+165 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Entsprechend der kategorialen (dichotomen) Natur der rekodierten Wissensitems 
+wurden Messmodelle mittels konfirmatorischer Faktorenanalyse unter Verwendung 
+des WLSMV-Schätzers in Mplus 6.1 (Muthén/Muthén 1998-2010) berechnet. Zur 
+Beurteilung der Modellpassung wurden neben dem Chi-Quadrat-Wert und den 
+Freiheitsgraden weitere gebräuchliche Fitindizes wie CFI (Comparative fit index), 
+RMSEA (Root mean square error of approximation) und WRMR (Weighted root 
+mean square residual) herangezogen. Nach Yu (2002) zeichnen sich Modelle mit 
+kategorialen Daten und guter Passung durch folgende Werte aus: CFI ≥ .96, RMSEA 
+≤ .05 und WRMR ≤ .95. Alle Analysen erfolgten unter Verwendung der Fallgewichte.3 
+Ergebnisse
+3.1 Itemstatistiken
+Die Entwicklung der Kurzskala erfolgte auf Basis des vorliegenden Datensatzes 
+durch Itemselektion aus der 32 Items umfassenden Gesamtskala nach den oben 
+genannten Kriterien (vgl. Abschnitt 2.4). In Tabelle 1 sind die Schwierigkeiten, die 
+Itemladungen (äquivalent zu Trennschärfen in der klassischen Testtheorie) und die 
+Tabelle 1 Schwierigkeiten und Trennschärfen der Kurzskala-ItemsItemNr. 
+Itembezeichner Wissensbereich Wissensdomäne p λ
+1 med Medizin Naturw. .88 .58
+2 rel Religion Geistesw. .69 .67
+3 geo Geografie Naturw. .78 .58
+4 kun Kunst Geistesw. .44 .64
+5 bio Biologie Naturw. .33 .45
+6 pol Politik Sozialw. .62 .52
+7 phi Philosophie Geistesw. .40 .51
+8 phy Physik Naturw. .44 .35
+9 lit Literatur Geistesw. .51 .56
+10 fin Finanzen Sozialw. .77 .58
+11 rec Recht Sozialw. .64 .39
+12 ges Geschichte Sozialw. .55 .46
+Anmerkungen: Naturw.: Naturwissenschaften; Geistesw.: Geisteswissenschaften; Sozialw.: Sozialwissenschaften; 
+p: relative Lösungshäufigkeit; λ: Itemladung im einfaktoriellen Messmodell (vgl. Abbildung 1, Modell b).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181166 
+inhaltliche Zuordnung zu den drei breiten Wissensdomänen bzw. den einzelnen 
+Wissensbereichen für die ausgewählten Items angegeben. Werden die entsprechenden 
+Summenscores herangezogen, korreliert die Kurzskala mit der Gesamtskala 
+zu r = .91.
+3.2 Messmodelle und Reliabilität
+Im Folgenden werden zwei konkurrierende Messmodelle für die Kurzskala gegenübergestellt 
+und hinsichtlich ihrer Passung verglichen. Im dreifaktoriellen Modell 
+werden drei Faktoren gemäß der drei breiten Wissensdomänen Natur-, Geistes- 
+und Sozialwissenschaften spezifiziert. Auf jedem der drei Faktoren laden dabei 
+nur die Items aus der entsprechenden Domäne. Da kristalline Intelligenz als übergeordnetes 
+Fähigkeitskonstrukt Wissen aller Bereiche umfasst, ist von positiven 
+Korrelationen zwischen den drei domänenspezifischen Faktoren auszugehen. Das 
+einfaktorielle Messmodell repräsentiert kristalline Intelligenz hingegen mit einem 
+einzigen Faktor, auf dem alle 12 Items der Kurzskala laden. Eine weitere Untergliederung 
+in verschiedene Wissensdomänen wird nicht modelliert. Das einfaktorielle 
+Modell stellt somit einen Spezialfall des komplexeren dreifaktoriellen Modells dar, 
+weshalb zum Modellvergleich auch die Differenz der Chi-Quadrat-Werte formal 
+auf Signifikanz getestet werden kann (Schulze 2004). Die beiden Messmodelle sind 
+in Abbildung 1 dargestellt; die Passung der Modelle kann Tabelle 2 entnommen 
+werden.
+Das dreifaktorielle Modell (a) weist eine signifikant bessere Passung auf 
+(∆χ²(N = 1.134, 3) = 15.2, p = .002), was sich auch an den anderen in Tabelle 2 
+ausgewiesenen Fitindizes zeigt. Der Unterschied ist allerdings gering; auch für das 
+einfaktorielle Modell (b) ergibt sich eine zufriedenstellende Passung. Übereinstimmend 
+mit dem geringen Unterschied in der Modellpassung zeigen sich im dreifaktoriellen 
+Modell hohe messfehlerbereinigte Korrelationen zwischen den drei Wissensdomänen, 
+die zwischen .80 und .96 liegen.
+Für die folgenden Analysen wird das einfaktorielle Messmodell verwendet, 
+da es eine zufriedenstellende Passung aufweist, die nur geringfügig schlechter ist 
+als die Passung des dreifaktoriellen Modells. Insbesondere ist der inhaltliche Mehrwert 
+des dreifaktoriellen Modells fraglich, da die drei breiten Wissensdomänen hoch 
+zusammenhängen und in der Kurzskala nur durch jeweils vier Items repräsentiert 
+werden, wodurch eine substanzielle Interpretation dieser spezifischeren Faktoren 
+erschwert wird. Für das einfaktorielle Messmodell ergibt sich eine zufriedenstellende 
+Reliabilität der latenten Variable von ω = .82 (McDonald 1999) bzw. α = .81 
+(Zumbo/Gadermann/Zeisser 2007). Die Reliabilität des manifesten Summenscores 
+167 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+liegt bei .70 (Raykov/Dimitrov/Asparouhov 2010). Die entsprechenden Werte für 
+die Gesamtskala mit 32 Items liegen mit .91 (ω/α) bzw. .84 (Skalenreliabilität nach 
+Raykov et al. 2010) wegen der höheren Itemzahl erwartungsgemäß höher.
+3.3 Überprüfung von Boden- und Deckeneffekten
+Da bei Kurzskalen nur wenige Items eingesetzt werden, besteht im Vergleich zu 
+umfangreicheren Skalen ein höheres Risiko von Boden- bzw. Deckeneffekten, d.h. 
+mangelnder Differenzierungsfähigkeit innerhalb von Personengruppen mit sehr 
+niedriger bzw. sehr hoher Fähigkeitsausprägung. Um zu überprüfen, ob solche 
+Tabelle 2 Fitstatistiken konkurrierender Messmodelle
+Modell χ² df CFI RMSEA WRMR
+3 Faktoren 94.9 51 .973 .027 0.97
+1 Faktor 110.8 54 .965 .030 1.06
+Anmerkungen: χ²: Chi-Quadrat-Wert; df: Anzahl der Freiheitsgrade; CFI: Comparative fit index; RMSEA: Root mean 
+square error of approximation; WRMR: Weighted root mean square residual.
+Abbildung 1 Dreifaktorielles (a) und einfaktorielles Messmodell (b) der Kurzskala
+Anmerkungen: Naturw.: Naturwissenschaften; Geistesw.: Geisteswissenschaften; Sozialw.: Sozialwissenschaften, 
+gc: kristalline Intelligenz; zu den Itembezeichnern siehe Tabelle 1.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181168 
+Effekte vorliegen, wird im Folgenden zunächst die Verteilung des Summenwerts der 
+Kurzskala in der Gesamtpopulation betrachtet (vgl. Abbildung 2). Zudem erfolgt 
+eine Betrachtung zweier Subpopulationen mit geringer bzw. hoher Schulbildung 
+(vgl. Abbildung 3). Die Subpopulation mit „geringer Schulbildung“ umfasst sowohl 
+Personen ohne Schulabschluss als auch Personen mit Hauptschulabschluss (bzw. 
+Äquivalent), die in der Regel nach der achten oder neunten Klasse die allgemeinbildende 
+Schule verlassen haben. Ihr Anteil an der erwachsenen deutschen Wohnbevölkerung 
+beträgt gemäß der vorliegenden Erhebung 45%. Personen mit „hoher 
+Schulbildung“ im Sinne der hier vorgenommenen Analyse verfügen demgegenüber 
+über eine fachgebundene oder allgemeine Hochschulreife bzw. Fachhochschulreife 
+(26% der Gesamtpopulation), die typischerweise nach 12 oder 13 Jahren Schulbesuch 
+erworben wurde. 
+Tabelle 3 gibt die Kennwerte der Verteilungen wieder. Für die Gesamtpopulation 
+zeigen sich keine nennenswerten Boden- oder Deckeneffekte. Zwar liegt eine 
+gering negative Schiefe vor, d.h. am oberen Ende der Fähigkeitsskala ist die Differenzierungsfähigkeit 
+minimal geringer. Dies ist jedoch praktisch kaum bedeutsam: 
+Der Anteil der Personen, die alle Wissensitems der Kurzskala richtig beantworten 
+können, liegt in der Gesamtpopulation unter vier Prozent; im Mittel werden etwa 
+sieben Items richtig gelöst. Ein differenzierteres Bild ergibt sich erwartungsgemäß 
+für die zwei betrachteten Subpopulationen, die sich in der mittleren Lösungshäufigkeit 
+deutlich unterscheiden. Während Personen mit „geringer Schulbildung“ im 
+Mittel weniger als sechs Items richtig beantworten, liegt der Mittelwert in der Subpopulation 
+mit „hoher Schulbildung“ etwas unter neun Items. Konkret beträgt die 
+standardisierte Mittelwertdifferenz zwischen den beiden Subpopulationen d = 1.12 
+Standardabweichungseinheiten. In der relativ großen Gruppe der Personen ohne 
+Schulabschluss bzw. mit Hauptschulabschluss liegt kein Bodeneffekt vor, hier liegt 
+die Schiefe nahe null. Für die kleinere Gruppe der Personen mit Hochschulreife 
+tritt erwartungsgemäß ein Deckeneffekt auf. Selbst in dieser sehr leistungsstarken 
+Personengruppe liegt jedoch der Anteil derer, die alle Items richtig beantworten, 
+unter 10 Prozent.
+3.4 Zusammenhänge mit Kriterien
+Ein wesentlicher Aspekt bei der Entwicklung und Beurteilung von Kurzskalen 
+besteht in deren Beziehungen zu relevanten Personen- und Umweltmerkmalen 
+sowie anderen psychologischen Konstrukten. Diese sollen einerseits im Einklang 
+mit der Literatur stehen (Konstruktvalidierung). Andererseits sollen die für die 
+Kurzskala ermittelten Beziehungen möglichst den Befunden für die ungekürzte 
+169 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Abbildung 2 Verteilung des Summenwerts der Kurzskala in der 
+Gesamtpopulation
+Abbildung 3 Verteilung des Summenwerts der Kurzskala in zwei 
+Subpopulationen
+Tabelle 3 Kennwerte verschiedener Personenverteilungen für den 
+Summenwert der Kurzskala
+Population N M SD Schiefe Exzess
+Gesamtpopulation 1.134 7.04 2.66 -0.20 0.64„Geringe 
+Schulbildung“ 514 5.95 2.49 +0.06 0.17„Hohe 
+Schulbildung“ 290 8.66 2.27 -0.52 0.38Anmerkungen: 
+N: Stichprobengröße; M: arithmetisches Mittel; SD: Standardabweichung.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181170 
+Gesamtskala entsprechen, um sicherzustellen, dass die Itemselektion keine substanzielle 
+Minderung der Konstruktvalidität zur Folge hat (Widaman/Little/Preacher/
+Sawalani 2011). Im Folgenden werden daher die Korrelationen der Kurzskala mit 
+verschiedenen Kovariaten näher betrachtet und den entsprechenden Korrelationen 
+der Gesamtskala mit 32 Wissensitems gegenübergestellt (vgl. Tabelle 4). Zu 
+den betrachteten Personenvariablen zählen Geschlecht, Alter, formale Bildung und 
+sozioökonomischer Status der Teilnehmenden. Darüber hinaus werden an dieser 
+Stelle auch Merkmale des Haushalts der Befragten (Haushaltsnettoeinkommen) 
+sowie des elterlichen Haushalts analysiert (sozioökonomischer Status der Eltern, 
+Anzahl der Bücher im elterlichen Haushalt zur Jugendzeit der Teilnehmenden), 
+die als Indikatoren für Umfang und Reichhaltigkeit der früheren oder aktuellen 
+Lernumwelt angesehen werden. Mit Blick auf psychologische Konstrukte werden 
+die Beziehungen zu den fünf Hauptdimensionen der Persönlichkeit (Big Five) und 
+zu selbstberichtetem Wissen untersucht. Bei der Interpretation der im folgenden 
+dargestellten Beziehungen ist zu beachten, dass es sich um messfehlerbehaftete 
+Korrelationen zwischen manifesten Variablen handelt. Zur Einordnung der Größe 
+der Effekte kann eine Orientierung an Cohen (1988) erfolgen, der für Produkt-MomentKorrelationen 
+Werte um .10 als kleine Effekte, Werte um .30 als mittlere 
+Effekte und Werte um .50 als große Effekte betrachtet. Wesentlicher ist jedoch der 
+Vergleich der hier ermittelten Zusammenhänge mit den in der Einleitung dargestellten 
+Erwartungen.
+In Übereinstimmung mit der Literatur zeigen Männer etwas höhere Wissensleistungen 
+als Frauen. Die standardisierte Mittelwertdifferenz beträgt d = 
+.30 und ist somit inhaltlich bedeutsam, obgleich niedriger als von Ackerman et 
+al. (2001) berichtet4. Wie erwartet wird in der hier untersuchten Erwachsenenpopulation 
+kein bedeutsamer Alterseffekt beobachtet. Deklaratives Wissen weist 
+eine hohe positive Korrelation mit dem ISCED-97 als Indikator formaler Bildung 
+auf, der sowohl Schul- als auch Ausbildungsabschlüsse berücksichtigt: Für 
+kein anderes hier untersuchtes Personen- oder Umweltmerkmal wurden höhere 
+Korrelationen gefunden. Eine ebenfalls starke Beziehung zeigt sich zu dem 
+auf der ISEI-Skala quantifizierten sozioökonomischen Status der Teilnehmenden. 
+Auch für die anderen in Tabelle 4 genannten Personen- und Haushalts4 
+Für Männer und Frauen kann von Messinvarianz ausgegangen werden, d.h. die Kurzskala 
+misst in beiden Gruppen dasselbe Konstrukt mit vergleichbarer Genauigkeit. Ein 
+entsprechend restringiertes Multigruppenmodell unter Annahme strikter Messinvarianz 
+zeigte sowohl für die Kurzskala mit 12 Items als auch für die Gesamtskala mit 
+32 Wissensitems eine befriedigende Passung (Werte für die Kurzskala: χ² = 203.7, 
+df = 130, RMSEA = .032, CFI = .953, WRMR = 1.548). Der latente Mittelwertunterschied 
+betrug 0.32 SD zugunsten der Männer.
+171 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+merkmale liegen inhaltlich bedeutsame positive Korrelationen mit Wissen vor, 
+die jedoch niedriger als die Zusammenhänge mit ISCED-97 und ISEI ausfallen. 
+Mit Blick auf die psychologischen Konstrukte liegt erwartungsgemäß eine 
+vergleichsweise hohe Korrelation mit selbstberichtetem Wissen vor. Für die fünf 
+Persönlichkeitsdimensionen ergibt sich ein differenziertes Ergebnismuster, das im 
+Wesentlichen mit den in der Literatur berichteten Befunden übereinstimmt. Die 
+Offenheitsdimension weist im Vergleich mit den anderen Big Five-Dimensionen die 
+vom Betrag her höchste Korrelation mit Wissen auf. Auch die gering positive Korrelation 
+mit Extraversion, die gering negative Beziehung zu Neurotizismus sowie die 
+nicht signifikante Korrelation mit Verträglichkeit entsprechen den metaanalytisch 
+gewonnenen Ergebnissen von Ackerman und Heggestad (1997). Eine Abweichung 
+lässt sich allein für Gewissenhaftigkeit feststellen: Während Ackerman und Heggestad 
+(1997) hier eine negative Korrelation mit Wissen bzw. eine nicht signifikante 
+Tabelle 4 Korrelationen der Kurz- und Gesamtskala mit verschiedenen 
+Personen- und Haushaltsmerkmalen sowie psychologischen 
+Konstrukten
+Variable Nvi
+Kurzskala Gesamtskala
+r SE r SE
+Geschlecht1 1.134 -.15 .03 -.15 .03
+Alter 1.134 .01n.s. .03 .00 n.s. .03
+ISCED-97 1.091 .49 .03 .51 .03
+ISEI 388 .44 .04 .45 .04
+HISEI Eltern 1.082 .25 .03 .25 .03
+Einkommen 638 .29 .04 .30 .04
+Anzahl Bücher 1.101 .30 .03 .33 .03
+selbstber. Wissen2 1.134 .52 .03 .55 .03
+Neurotizismus3 1.104 -.10 .03 -.15 .03
+Extraversion3 1.104 .07a .04 .12 .04
+Offenheit3 1.104 .21 .03 .25 .03
+Gewissenhaftigkeit3 1.104 .07a .03 .09 .03
+Verträglichkeit3 1.104 -.02n.s. .03 -.02 n.s. .03
+Anmerkungen: N = 1.134. 1 0 = männlich, 1 = weiblich; 2 selbstberichtetes Wissen (VOC-T Treffer); 3 Big Five-Dimensionen; 
+a p < .05; n.s. nicht signifikant; Nvi: Fallzahl vor der Imputation; r: punkt-biseriale Korrelation (Geschlecht), 
+polyseriale Korrelation (ISCED-97, Bücher), Produkt-Moment-Korrelation (alle anderen Variablen); SE: Standardfehler; 
+ISCED-97: International Standard Classification of Education, Fassung 1997; ISEI: International SocioEconomic 
+Index of Occupational Status; HISEI Eltern: Höchster ISEI-Wert der beiden Elternteile des Teilnehmenden. 
+Sofern nicht anders gekennzeichnet, sind alle Korrelationen signifikant von null verschieden (p < .01).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181172 
+Korrelation mit kristalliner Intelligenz berichten, wird in der aktuellen Analyse eine 
+gering positive Beziehung zwischen Wissen und Gewissenhaftigkeit gefunden. Für 
+alle berichteten Kovariaten ergeben sich im Vergleich von Kurz- und Gesamtskala 
+sehr ähnliche Korrelationen. 
+4 Diskussion
+Da der Umfrageforschung im deutschen Sprachraum bis dato nur wenige frei verfügbare 
+und erprobte Instrumente zur Erfassung kognitiver Fähigkeiten vorliegen, 
+war das Ziel dieses Beitrags die Entwicklung einer Kurzskala zur Messung kristalliner 
+Intelligenz (gc) und die Prüfung ihrer psychometrischen Eigenschaften. Die hier 
+beschriebene Kurzskala BEFKI GC-K umfasst 12 Items, die in Übereinstimmung mit 
+der Definition von gc durch Cattell (1971) bzw. Carroll (1993) deklaratives Wissen 
+aus ebensovielen Bereichen der Natur-, Geistes- und Sozialwissenschaften erfassen. 
+Somit wird innerhalb von fünf Minuten Bearbeitungszeit ein möglichst breites 
+Wissensspektrum berücksichtigt. Durch Einbezug von Items unterschiedlicher 
+Schwierigkeit gelang es, trotz der vergleichsweise geringen Itemanzahl Boden- und 
+Deckeneffekte in der erwachsenen deutschen Wohnbevölkerung fast vollständig zu 
+vermeiden. Lediglich in der besonders leistungsstarken Subpopulation mit Hochschulabschluss 
+bzw. Fachhochschulabschluss trat ein geringer Deckeneffekt auf. 
+Weiterhin weist die Kurzskala eine gute Reliabilität auf, welche gängige Standards 
+für die Forschung erfüllt. Die zeitliche Stabilität der Testwerte konnte aufgrund der 
+querschnittlichen Natur der Erhebung nicht geprüft werden. Daten einer mit Schülerinnen 
+und Schülern der Mittelstufe durchgeführten Längsschnittuntersuchung 
+mit Wissensitems aus dem BEFKI-Pool legen jedoch eine befriedigende zeitliche 
+Stabilität nahe (Wilhelm et al., in Vorbereitung).
+Sowohl für ein einfaktorielles Messmodell als auch für ein mehrdimensionales 
+Modell, das drei korrelierte Faktoren gemäß der Unterscheidung zwischen 
+Natur-, Geistes- und Sozialwissenschaften spezifiziert, ergab sich eine zufriedenstellende 
+Passung bei statistisch signifikanter Überlegenheit des dreifaktoriellen 
+Modells. Die Bevorzugung des eindimensionalen Modells im vorliegenden Beitrag 
+beruht auf mehreren Argumenten: Erstens ist zu berücksichtigen, dass der 
+χ²-Differenztest von der Stichprobengröße abhängig ist und daher in der vorliegenden, 
+vergleichsweise großen Stichprobe auch inhaltlich unbedeutende Unterschiede 
+als signifikant ausgewiesen werden. Zweitens ist das einfaktorielle Modell 
+insofern theoretisch fundiert, als Wissen aus verschiedenen Bereichen in konsensualen 
+Intelligenzstrukturtheorien einem gemeinsamen, bereichsübergreifenden gc173 
+Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Faktor untergeordnet ist (Horn/Noll 1997; Carroll 1993, 2003; McGrew 2009). Dies 
+wird auch empirisch durch die sehr hohen Korrelationen zwischen den Wissensfaktoren 
+im dreidimensionalen Modell gestützt. Drittens ist zu berücksichtigen, 
+dass die spezifischeren Faktoren des dreidimensionalen Modells mit nur jeweils vier 
+Items extrem schmal operationalisiert sind. Eine inhaltliche Interpretation dieser 
+Faktoren wäre fragwürdig, da die Itemstichprobe aufgrund dieser sehr geringen 
+Itemzahl keine Repräsentativität für die jeweilige Wissensdomäne beanspruchen 
+kann (Ackerman 2000). Ferner ist die im Vergleich zu einem Gesamtwert geringere 
+Reliabilität von Subskalen zu berücksichtigen (Sinharay 2010). Im Extremfall kann 
+dies dazu führen, dass der Gesamttestwert einen besseren Prädiktor der Personenfähigkeit 
+auf einer Subdimension darstellt als der entsprechende Subskalenwert 
+(Sinharay/Haberman/Puhan 2007). Selbst bei vermeintlich ausreichender Reliabilität 
+einer Subskala kann diese durch die übergeordnete Fähigkeit bedingt sein statt 
+durch die spezifische Subdimension (Reise/Moore/Haviland 2010).
+Die Validität der gc-Kurzskala wurde anhand der Korrelationen des Gesamtwertes 
+mit verschiedenen Personen- und Umweltmerkmalen einerseits sowie 
+ausgewählten psychologischen Konstrukten andererseits überprüft, wobei diese 
+Beziehungen fast durchgängig mit den auf Basis der Fachliteratur formulierten 
+Erwartungen übereinstimmten. Die Höhe der untersuchten Effekte bzw. Zusammenhänge 
+lag für die Kurzskala mit 12 Items nur geringfügig unter den entsprechenden 
+Werten für die ungekürzte Wissensskala mit 32 Items; die Abweichungen 
+lassen sich durch die etwas geringere Reliabilität der Kurzskala erklären. Im Einzelnen 
+wurde übereinstimmend mit den oben zitierten Befunden ein Geschlechtsunterschied 
+im deklarativen Wissen zugunsten von Männern gefunden. Dies stellt 
+keine Verzerrung und somit unfaire Messung dar, sondern repliziert den Befund 
+von Ackerman et al. (2001), dass bei einem umfassenden Sampling von Items aus 
+vielen verschiedenen Wissensbereichen in den meisten dieser Bereiche ein Wissensvorsprung 
+der Männer zu beobachten ist. Dass der Mittelwertunterschied in 
+der hier vorgestellten Skala weniger deutlich ausfällt, könnte auf kulturelle Unterschiede 
+zurückzuführen sein oder darin begründet liegen, dass andere Studien teilweise 
+deutlich größere Itemmengen eingesetzt haben, einschließlich sehr spezifischer 
+Wissensfragen, die als berufsspezifische Expertise einzuordnen sind (vgl. den 
+gkn-Faktor im CHC-Modell; McGrew 2009). In der vorliegenden Kurzskala wurde 
+hingegen auf derartige Items zu hochspezifischem Wissen verzichtet, da sie nur 
+innerhalb bestimmter Subpopulationen funktionieren. Dies ist auch ein Grund 
+dafür, dass kein substanzieller Zusammenhang zwischen der gc-Kurzskala mit dem 
+Alter festgestellt werden konnte. Mit Blick auf die hohe Stabilität kristalliner Intelligenz 
+im Erwachsenenalter war ein kleiner oder nicht signifikanter Effekt erwartet 
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181174 
+worden. Zwar werden in der Literatur Wissenszuwächse auch im jungen und mittleren 
+Erwachsenenalter berichtet (Ackerman 2000), diese beziehen sich aber auf 
+Expertise im Sinne von Wissen, das erst im Erwachsenenalter erworben werden 
+kann, beispielsweise im Rahmen der Berufsausübung (Ackerman 1996). Zum anderen 
+umfasst die untersuchte Population neben jungen Erwachsenen auch Erwachsene 
+in sehr hohem Alter, für die in der Literatur biologisch bedingt abnehmende 
+Leistungen auch in Tests kristalliner Fähigkeiten berichtet werden (Li 2003). 
+Erwartungskonform sind ebenfalls die substanziellen positiven Beziehungen 
+der Kurzskala mit Indikatoren der formalen Bildung und der Reichhaltigkeit 
+der Lernumwelt, die im sozioökonomischen Status zum Ausdruck kommt. Sowohl 
+ISCED-97 als auch ISEI der Teilnehmenden hängen mit dem über einen langen 
+Zeitraum in einer Vielzahl von Bereichen erworbenen Wissen zusammen. Die vergleichsweise 
+niedrigeren Korrelationen mit dem sozioökonomischen Status der 
+Eltern, dem Haushaltsnettoeinkommen sowie der Anzahl der Bücher im elterlichen 
+Haushalt zur Jugendzeit der Teilnehmenden sind insofern plausibel, als es sich dabei 
+um eher indirekte bzw. inhaltlich weniger breite Indikatoren handelt, die begrenzte 
+Aussagekraft bzgl. der Lernumwelt haben. 
+Mit Blick auf andere psychologische Konstrukte konnte gezeigt werden, 
+dass eine relativ hohe positive Korrelation zwischen der Kurzskala und selbstberichtetem 
+Wissen vorliegt. Dieser Befund überrascht nicht, da beide Skalen auf 
+deklaratives Wissen abzielen und die Auswahl der erfassten Wissensbereiche in 
+beiden Messverfahren auf der Systematik von Ackerman (2000) beruht. Dass kein 
+perfekter Zusammenhang vorliegt, dürfte – neben der Tatsache, dass die berichteten 
+Korrelationen messfehlerbehaftet sind – insbesondere an der unterschiedlichen 
+Natur der Messverfahren liegen (Selbstauskünfte versus tatsächliches Wissen). Die 
+Beziehungen der gc-Kurzskala zu den Big Five zeigten ein Korrelationsmuster, das 
+mit den metaanalytischen Befunden von Ackerman und Heggestad (1997) weitgehend 
+übereinstimmt. Die höchste Korrelation wies die gc-Kurzskala wie erwartet 
+mit der Offenheitsdimension auf. Im Widerspruch zu den Ergebnissen von Ackerman 
+und Heggestad (1997) steht lediglich die leicht positive Korrelation mit der 
+Gewissenhaftigkeitsdimension. Hierbei ist jedoch zu bedenken, dass die diesbezügliche 
+Datenbasis in der genannten Metaanalyse sehr klein war und ein gering 
+positiver Zusammenhang zwischen Gewissenhaftigkeit und Wissensleistungen aus 
+theoretischer Sicht erklärbar ist. Man denke etwa an die umfangreiche Literatur 
+zur prädiktiven Validität von Gewissenhaftigkeit für den Berufserfolg (Barrick/
+Mount/Judge 2001). Befunde zu den Beziehungen der Kurzskala mit anderen gcIndikatoren 
+sowie mit gf liegen bisher nur für Langformen aus Pilotierungs- und 
+Normierungsstudien vor, die mit Schülerpopulationen durchgeführt wurden. Auf 
+175 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+der Ebene latenter Variablen konnte bei Schülerinnen und Schülern der achten bis 
+zehnten Jahrgangsstufe eine hohe Korrelation zwischen deklarativem Wissen und 
+Wortschatz (ρ = .93) und eine ebenfalls substanzielle Beziehung zwischen Wissen 
+und schlussfolgerndem Denken (ρ = .80) gezeigt werden (Wilhelm et al., in Vorbereitung).Bei 
+der Interpretation der im vorliegenden Beitrag berichteten Befunde ist 
+einschränkend zu berücksichtigen, dass die Itemselektion für die Kurzskala und 
+deren Evaluation auf derselben Erhebung basieren. Zudem lag für den Wissenstest 
+eine relativ strenge Zeitbegrenzung vor, die zu fehlenden Werten führte, da nicht 
+alle teilnehmenden Personen den Test in der vorgegebenen Zeit abschließen konnten. 
+Diese aufgrund der Zeitbegrenzung fehlenden Werte als Falschantworten zu 
+werten, hätte eine Verzerrung des Skalenwerts durch konstruktirrelevante Varianz 
+– etwa Unterschiede in mentaler Geschwindigkeit – zur Folge gehabt. Um diese 
+Verzerrung zu vermeiden, wurden daher fehlende Werte unter Berücksichtigung 
+aller verfügbaren Informationen imputiert; dadurch ist die größtmögliche Vergleichbarkeit 
+mit einer Durchführung ohne Zeitmangel gewährleistet. Eine Bearbeitungzeit 
+von fünf Minuten für die 12 Items der Kurzskala ist jedoch ausreichend, 
+so dass eine Imputation fehlender Werte unter diesen Durchführungsbedingungen 
+nicht erforderlich ist (stattdessen sollten ausgelassene Items wie Falschantworten 
+ausgewertet werden). In zukünftigen Studien sollte geprüft werden, inwiefern die 
+hier berichteten Befunde auf andere Stichproben und die veränderten Durchführungsbedingungen 
+übertragbar sind.
+5 Abschließende Bemerkungen
+Die hier vorgestellte Kurzskala BEFKI GC-K zur Erfassung kristalliner Intelligenz 
+stellt unseres Wissens das erste frei verfügbare Verfahren zur gc-Messung dar, das 
+sich aufgrund seiner Kürze und psychometrischen Effizienz für den Einsatz in der 
+Umfrageforschung eignet. Die Skala ist sowohl in technologiebasierten Testungen 
+(computer assisted personal interview/self-interview/web-interview) als auch bei 
+herkömmlichen Papier-Stift-Testungen (Selbstausfüller) leicht anzuwenden; neben 
+Einzeltestungen sind auch Gruppentestungen problemlos möglich. Einschränkend 
+gilt hier, dass die Bewährung der Kurzskala mit anderen Testmedien bislang nicht 
+geprüft wurde. Mit Blick auf die umfangreiche Literatur zu Testmedienvergleichen 
+(vgl. etwa Mead/Drasgow 1993; Schroeders/Wilhelm 2010) sind für die gc-Skala 
+bei ansonsten gleichen Durchführungsbedingungen jedoch keine nennenswerten 
+Testmedieneffekte zu erwarten. Gegenüber gängigen Bildungsindikatoren wie 
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181176 
+der ISCED-97 hat die Wissensskala den Vorteil, dass tatsächliches Wissen direkt 
+erhoben wird, anstatt es aus Abschlüssen zu erschließen. Letzteres ist insbesondere 
+deshalb problematisch, da Schul- und Ausbildungsabschlüsse einerseits zwischen 
+verschiedenen Bundesländern oder gar Staaten schwer vergleichbar sind 
+(Neumann/Nagy/Trautwein/Lüdtke 2009) und formale Abschlüsse andererseits 
+dem zeitlichen Wandel unterliegen. Zudem sind Selbstauskünfte wie Angaben zu 
+Bildungsabschlüssen oder zur Berufstätigkeit im Gegensatz zu objektiven Leistungstests 
+leicht verfälschbar (Ziegler/MacCann/Roberts 2011). Ungeachtet der 
+Vorzüge der hier vorgestellten gc-Skala ist jedoch zu berücksichtigen, dass es sich 
+um eine Kurzskala handelt, die zur Wissensmessung in der sehr bildungsheterogenen 
+erwachsenen Bevölkerung konstruiert wurde. Daher ist die inhaltliche Breite 
+der Messung stark eingeschränkt und kann eine differenzierte Wissensdiagnostik 
+nicht ersetzen. Stattdessen fokussiert die Kurzskala auf „Wissen, von dem angenommen 
+werden kann, dass es von einem großen Teil der Population geteilt wird“ 
+(Ackerman 2003: 16). Mithilfe komplexer Testdesigns und Modellierungsmethoden 
+ist es jedoch möglich, die Vorzüge von Kurzskalen mit den Vorteilen umfangreicher 
+Messinstrumente zu kombinieren (Rhemtulla/Little 2012).
+Die Kurzskala kann für nicht-kommerzielle Forschungszwecke kostenfrei 
+eingesetzt werden. Eine Druckvorlage ist über folgenden Link verfügbar:
+http://befki.de/materialien (Kennwort: trgw34785bns)
+Literatur
+Ackerman, P. L., 1996: A theory of adult intellectual development: Process, personality, 
+interests, and knowledge. Intelligence 22: 227–257.
+Ackerman, P. L., 2000: Domain-Specific Knowledge as the „Dark Matter“ of Adult Intelligence: 
+Gf/Gc, Personality and Interest Correlates. Journal of Gerontology: Psychological 
+Sciences 55B: 69-84.
+Ackerman, P. L., 2003: Cognitive ability and non-ability trait determinants of expertise. 
+Educational Researcher 32 (8): 15-20.
+Ackerman, P. L., 2008: Knowledge and cognitive aging. S. 445-489 in: F. I. M. Craik und T. 
+A. Salthouse (Hg.): The handbook of aging and cognition (3rd ed.). New York, NY, USA: 
+Psychology Press.
+Ackerman, P. L. und M. E. Beier, 2004: Knowledge and Intelligence. S. 125-139 in: O. Wilhelm 
+und R. Engle (Hg.): Handbook of understanding and measuring intelligence. Thousand 
+Oaks, CA: Sage.
+Ackerman, P. L., K. R. Bowen, M. B. Beier und R. Kanfer, 2001: Determinants of individual 
+differences and gender differences in knowledge. Journal of Educational Psychology 
+93: 797-825.
+Ackerman, P. L. und E. D. Heggestad, 1997: Intelligence, personality, and interests: Evidence 
+for overlapping traits. Psychological Bulletin 121: 219-245.
+177 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Ackerman, P. L. und E. L. Rolfhus, 1999: The locus of adult intelligence: Knowledge, abilities, 
+and non-ability traits. Psychology and Aging 14: 314–330.
+Baltes, P. B., 1987: Theoretical propositions of life-span developmental psychology: on the 
+dynamics between growth and decline. Developmental Psychology 23: 611-626.
+Baltes, P. B., U. M. Staudinger und U. Lindenberger, 1999: Lifespan Psychology: Theory and 
+Application to Intellectual Functioning. Annual Review of Psychology 50: 471-507.
+Barrick, M. R., M. K. Mount und T. A. Judge, 2001: Personality and performance at the 
+beginning of the new millennium: What do we know and where do we go next? International 
+Journal of Selection and Assessment 9: 9-20.
+Binet, A. und T. Simon, 1905: Méthodes nouvelles pour le diagnostic du niveau intellectuel 
+des anormaux. L‘année psychologique 11: 191-244.
+Brennan, R. L., 2001: Generalizability Theory. New York: Springer.
+Carroll, J. B., 1993: Human cognitive abilities: A survey of factor-analytic studies. New York: 
+Cambridge University Press.
+Carroll, J. B., 2003: The higher stratum structure of cognitive abilities: Current evidence 
+supports g and about ten broad factors. S. 153-193 in: H. Nyborg (Hg.): The scientific 
+study of general intelligence: Tribute to Arthur R. Jensen. New York: Pergamon.
+Cattell, R. B., 1943: The measurement of adult intelligence. Psychological Bulletin 40: 153-
+193.
+Cattell, R.B., 1963: Theory of fluid and crystallized intelligence: A critical experiment. Jounal 
+of Educational Psychology 54: 1-22.
+Cattell, R. B., 1971: Abilities: Their Structure, Growth, and Action. Boston, MA: Houghton 
+Mifflin.
+Ceci, S. J., 1991: How much does schooling influence general intelligence and its cognitive 
+components? A reassessment of the evidence. Developmental Psychology 27: 703–722.
+Cliffordson, C. und J.-E. Gustafsson, 2008: Effects of age and schooling on intellectual performance: 
+Estimates obtained from analysis of continuous variation in age and length 
+of schooling. Intelligence 36: 143-152.
+Cohen, J., 1988: Statistical Power Analysis for the Behavioral Sciences, 2nd ed. Hillsdale: 
+Lawrence Erlbaum Associates.
+Collins, L. M., J. L. Schafer und C.-M. Kam, 2001: A comparison of inclusive and restrictive 
+strategies in modern missing data procedures. Psychological Methods 6: 330-351.
+Cronbach, L. J., 1949: Essentials of psychological testing. New York: Harper. 
+Danthiir, V., R. D. Roberts, R. Schulze und O. Wilhelm, 2004: Mental Speed: On Frameworks, 
+Paradigms, and a Platform for the Future. S. 27-46 in: O. Wilhelm und R. W. Engle (Hg.): 
+Handbook of Understanding and Measuring Intelligence. London: Sage.
+Ebbinghaus, H., 1897: Über eine neue Methode zur Prüfung geistiger Fähigkeiten und ihre 
+Anwendung bei Schulkindern. Zeitschrift für Psychologie und Physiologie der Sinnesorgane 
+13: 401-459. 
+Ehmke, T. und T. Siegle, 2005: ISEI, ISCED, HOMEPOS, ESCS. Indikatoren der sozialen Herkunft 
+bei der Quantifizierung von sozialen Disparitäten. Zeitschrift für Erziehungswissenschaft 
+8: 521-539.
+Furnham, A. und G. Dissou, 2007: The relationship between self-estimated and test-derived 
+scores of personality and intelligence. Journal of Individual Differences 28: 37-44.
+Ganzeboom, H. B. G., P. M. De Graaf und D. J. Treiman, 1992: A Standard International 
+Socio-Economic Index of Occupational Status. Social Science Research 21: 1-56.
+Grabner, R. H. und E. Stern, 2010: Measuring Cognitive Ability. S. 753-768 in: Rat für So-zial 
+und Wirtschaftsdaten (Hg.): Building on progress: Expanding the research infrastructure 
+for the social, economic, and behavioral sciences. Opladen: Budrich UniPress.
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181178 
+Graham, J. W., A. E. Olchowski und T. D. Gilreath, 2007: How many imputations are really 
+needed? Some Practical Clarifications of Multiple Imputation Theory. Prevention Science 
+8: 206-213.
+Hebb, D. O., 1942: The effect of early and late brain injury upon test scores and the nature 
+of normal adult intelligence. Proceedings of the American Philosophical Society 85: 
+275-292.
+Horn, J. L., 1965: Fluid and crystallized intelligence: A factor analytic study of the structure 
+among primary mental abilities. Dissertation, University of Illinois.
+Horn, J. L., 1988: Thinking about human abilities. S. 645-685 in: J. R. Nesselroade (Hg.): 
+Handbook of multivariate psychology. New York: Academic Press.
+Horn, J. L., und R. B. Cattell, 1966: Refinement and test of the theory of fluid and crystallized 
+general intelligences. Journal of Educational Psychology 57: 253-270.
+Horn, J. L. und J. Noll, 1997: Human cognitive capabilities: Gf–Gc theory. S. 53-91 in: D. P. 
+Flanagan, J. L. Genshaft und P. L. Harrison (Hg.): Contemporary intellectual assessment: 
+Theories, tests and issues. New York: Guilford.
+Hülür, G., O. Wilhelm und S. Schipolowski, 2011: Prediction of self-reported knowledge with 
+over-claiming, fluid and crystallized intelligence and typical intellectual engagement. 
+Learning and Individual Differences 21: 742-746. 
+ILO, 2007: International Standard Classification of Occupations ISCO-08. http://www.ilo.
+org/public/english/bureau/stat/isco/isco08/index.htm (26.11.2012).
+Lang, F. R., D. Weiss, A. Stocker und B. von Rosenbladt, 2007: Assessing Cognitive Capacities 
+in Computer-Assisted Survey Research: Two Ultra-Short Tests of Intellectual Ability in 
+the German Socio-Economic Panel (SOEP). Schmollers Jahrbuch 127: 183-192.
+Li, S.-C, 2003: Biocultural orchestration of developmental plasticity across levels: The interplay 
+of biology and culture in shaping the mind and behavior across the life span. 
+Psychological Bulletin 129: 171-194.
+Lüdtke, O., A. Robitzsch, U. Trautwein und O. Köller, 2007: Umgang mit fehlenden Werten 
+in der psychologischen Forschung: Probleme und Lösungen. Psychologische Rundschau 
+58: 103-117.
+Lynn, R. und P. Irwing, 2002: Sex differences in general knowledge, semantic knowledge 
+and reasoning ability. British Journal of Psychology 93: 545-556.
+Lynn, R., P. Irwing und T. Cammock, 2001: Sex differences in general knowledge. Intelligence 
+30: 27-40.
+Lynn, R., S. Wilberg und J. Margraf-Stiksrud, 2004: Sex differences in general knowledge 
+in German high school students. Personality and Individual Differences 37: 1643-1650.
+Mead, A. D. und F. Drasgow, 1993: Equivalence of computerized and paper-and-pencil cognitive 
+ability tests: A meta-analysis. Psychological Bulletin 114: 449–458.
+McDonald, R. P., 1999: Test theory: A unified treatment. Mahwah, NJ: Erlbaum.
+McGrew, K. S., 2009: CHC theory and the human cognitive abilities project: Standing on 
+the shoulders of the giants of psychometric intelligence research. Intelligence 37: 1-10.
+Muthén, L. K. und B. O. Muthén, 1998-2010: Mplus User’s Guide. Sixth Edition. Los Angeles, 
+CA: Muthén & Muthén.
+Neumann, M., G. Nagy, U. Trautwein und O. Lüdtke, 2009: Vergleichbarkeit von Abiturleistungen: 
+Leistungs- und Bewertungsunterschiede zwischen Hamburger und BadenWürttemberger 
+Abiturienten und die Rolle zentraler Abiturprüfungen. Zeitschrift für 
+Erziehungswissenschaft 12: 691-714.
+Ostendorf, F. und A. Angleitner, 2004: NEO-Persönlichkeitsinventar nach Costa und McCrae, 
+Revidierte Fassung (NEO-PI-R). Göttingen: Hogrefe.
+179 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Paulhus, D. L. und P. D. Harms, 2004: Measuring cognitive ability with the overclaiming 
+technique. Intelligence 32: 297-314.
+Rammstedt, B., C. J. Kemper, M. C. Klein, C. Beierlein und A. Kovaleva, 2012: Eine kurze Skala 
+zur Messung der fünf Dimensionen der Persönlichkeit: Big-Five-Inventory-10 (BFI-10). 
+GESIS-Working Papers 2012|23. Köln: GESIS.
+Rammstedt, B. und O. P. John, 2007: Measuring personality in one minute or less: A 10-item 
+short version of the Big Five Inventory in English and German. Journal of Research in 
+Personality 41: 203-212.
+Rat für Sozial- und Wirtschaftsdaten, 2010: Building on progress: Expanding the research 
+infrastructure for the social, economic, and behavioral sciences. Opladen: Budrich UniPress.Raykov, 
+T., D. M. Dimitrov und T. Asparouhov, 2010: Evaluation of scale reliability with binary 
+measures using latent variable modeling. Structural Equation Modeling: A Multidisciplinary 
+Journal 17: 265–279.
+Reise, S. P., T. M. Moore und M. G. Haviland, 2010: Bifactor Models and Rotations: Exploring 
+the Extent to Which Multidimensional Data Yield Univocal Scale Scores. Journal of 
+Personality Assessment 92: 544–559.
+Rhemtulla, M. und T. D. Little, 2012: Planned Missing Data Designs for Research in Cognitive 
+Development. Journal of Cognition and Development 13: 425-438.
+Rolfhus, E. L. und P. L. Ackerman, 1999: Assessing individual differences in knowledge: 
+Knowledge structures and traits. Journal of Educational Psychology 91: 511-526.
+Rowe, D. C., K. C. Jacobson und E. J. van den Oord, 1999: Genetic and environmental influences 
+on vocabulary IQ: parental education level as moderator. Child Development 70: 
+1151–1162.
+Rubin, D. B., 1976: Inference and missing data. Biometrika 63: 581-592.
+Schipolowski, S., U. Schroeders und O. Wilhelm, 2008: BEFKI - Berlin Test of Fluid and Crystallized 
+Intelligence. Präsentation auf dem XXIX International Congress of Psychology, 
+Berlin. 
+Schroeders, U. und O. Wilhelm, 2010: Testing reasoning ability with handheld computers, 
+notebooks, and paper and pencil. European Journal of Psychological Assessment 26: 
+284–292.
+Schroeders, U., S. Schipolowski, C. Nelles und O. Wilhelm, 2011: Interest, domain specific 
+knowledge, and fluid intelligence: Profile covariances and prediction of vocational training 
+success. Präsentation auf dem 15th Biennial Meeting of the International Society 
+for the Study of Individual Differences, London, UK. 
+Schroeders, U., S. Schipolowski und O. Wilhelm, 2010: Berliner Test zur Erfassung fluider 
+und kristalliner Intelligenz. Präsentation auf dem 47. Kongress der Deutschen Gesellschaft 
+für Psychologie, Bremen.
+Schulze, R., 2004: Modeling Structures of Intelligence. S. 241-263 in O. Wilhelm und R. 
+Engle (Hg.): Handbook of understanding and measuring intelligence. Thousand Oaks, 
+CA: Sage.
+Sinharay, S., 2010: How Often Do Subscores Have Added Value? Results from Operational 
+and Simulated Data. Journal of Educational Measurement 47: 150-174.
+Sinharay, S., S. Haberman und G. Puhan, 2007: Subscores Based on Classical Test Theory: To 
+Report or Not to Report. Educational Measurement: Issues and Practice 26 (4): 21-28.
+Spearman, C. E., 1938: Measurement of intelligence. Scientia 64: 75-82.
+UNESCO, 1997: International Standard Classification of Education ISCED 1997. http://www.
+unesco.org/education/information/nfsunesco/doc/isced_1997.htm (20.11.2012).
+methoden, daten, analysen · 2013, Jg. 7(2), S. 153-181180 
+Widaman, K. F., T. D. Little, K. J. Preacher und G. M. Sawalani, 2011: On creating and using 
+short forms of scales in secondary research. S. 39-61 in: K. H. Trzesniewski, M. B. Donnellan 
+und R. E. Lucas (Hg.): Secondary Data Analysis: An Introduction for Psychologists. 
+Washington, DC: American Psychological Association.
+Wilhelm, O. und S. Schipolowski, 2010: Intelligenzdiagnostik in der Pädagogischen Psychologie. 
+In G. L. Huber (Hg.): Enzyklopädie Erziehungswissenschaft Online. Fachgebiet Pädagogische 
+Psychologie. Weinheim/München: Juventa. 
+Wilhelm, O., U. Schroeders und S. Schipolowski, in Vorbereitung: BEFKI – Berliner Test zur 
+Erfassung fluider und kristalliner Intelligenz. Mittelstufenform. Göttingen: Hogrefe.
+Wolf, C., 1995: Sozio-ökonomischer Status und berufliches Prestige. ZUMA-Nachrichten 
+37: 102-136.
+Von der Heyde, C., 2009: Das ADM-Stichprobensystem für persönlich-mündliche Befragungen. 
+http://www.adm-ev.de/fileadmin/user_upload/PDFS/Beschreibung-ADM-Stichpro 
+ben-f2f_DE.pdf (30 KB) (20.11.2012)
+Von Stumm, S. und P. L. Ackerman, 2012: Investment and Intellect: A Review and MetaAnalysis. 
+Psychological Bulletin: Advance online publication, doi: 10.1037/a0030746.
+Yu, C. Y., 2002: Evaluating cutoff criteria of model fit indices for latent variable models 
+with binary and continuous outcomes. Doctoral dissertation, University of California, 
+Los Angeles.
+Ziegler, M., E. Danay, M. Heene, J. Asendorpf und M. Bühner, 2012: Openness, fluid intelligence, 
+and crystallized intelligence: Toward an integrative model. Journal of Research 
+in Personality 46: 173-183.
+Ziegler, M., C. J. Kemper und B. Rammstedt, 2013: The Vocabulary and Overclaiming Test 
+(VOC-T). Journal of Individual Differences 34: 32-40.
+Ziegler, M., C. MacCann und R. D. Roberts, 2011: New Perspectives on Faking in Personality 
+Assessment. New York: Oxford University Press.
+Zumbo, B. D., A. M. Gadermann und C. Zeisser, 2007: Ordinal versions of coefficients alpha 
+and theta for Likert rating scales. Journal of Modern Applied Statistical Methods 6: 
+21-29.
+181 Schipolowski et al.: Eine Kurzskala zur Messung kristalliner Intelligenz
+Anschrift des Autors Stefan Schipolowski
+ Humboldt-Universität zu Berlin
+ Institut zur Qualitätsentwicklung im Bildungswesen
+ Unter den Linden 6
+ 10099 Berlin
+ stefan.schipolowski@iqb.hu-berlin.deKo-Autor/innen 
+Oliver Wilhelm
+ Institut für Psychologie und Pädagogik
+ Universität Ulm
+ Ulrich Schroeders
+ Institut zur Qualitätsentwicklung im Bildungswesen
+ Humboldt-Universität zu Berlin
+ Anastassiya Kovaleva
+ Fakultät für Biologie, Universität Bielefeld
+ Christoph J. Kemper
+ Institut für medizinische und pharmazeutische 
+ Prüfungsfragen, Mainz
+ Beatrice Rammstedt
+ GESIS – Leibniz-Institut für Sozialwissenschaften, 
+ Mannheim
+ 


### PR DESCRIPTION
main changes:
1. Extraction of bibliography moved to separate class (BibliographyExtractor), no longer part of text extraction
2. BibliographyExtractor no longer needs pages from text extraction, instead constructs sections itself. It can thus be applied on existing text files but also during text extraction as before.
3. Added a util class for computation of precision and recall scores
4. Added a test class and a yet small set of gold and test texts.
5. TextExtractor accepts a flag that determines whether existing text files are to be overwritten (same behaviour as before) or correspoding pdf files skipped. In text extraction mode in CLI, default: skip
