### PR TITLE
Update jersey: 2.17 -> 2.22.1, #81, #69

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,11 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.12'
 
     // Jersey / JAX-RS / JSON / XML
-    compile 'org.glassfish.jersey.core:jersey-server:2.17'
-    compile 'org.glassfish.jersey.core:jersey-client:2.17'
-    compile 'org.glassfish.jersey.media:jersey-media-json-jackson:2.17'
-    compile 'org.glassfish.jersey.media:jersey-media-multipart:2.17'
-    compile 'org.glassfish.jersey.containers:jersey-container-servlet:2.17'
+    compile 'org.glassfish.jersey.core:jersey-server:2.22.1'
+    compile 'org.glassfish.jersey.core:jersey-client:2.22.1'
+    compile 'org.glassfish.jersey.media:jersey-media-json-jackson:2.22.1'
+    compile 'org.glassfish.jersey.media:jersey-media-multipart:2.22.1'
+    compile 'org.glassfish.jersey.containers:jersey-container-servlet:2.22.1'
     compile 'org.glassfish:javax.json:1.0.4'
 
     // Reflections


### PR DESCRIPTION
Travis CI complains about one of those regex tests failing, but other than that, I don't see any problems. 

Other than that, it is working fine with infolis/infolis-web and a dozen `make redeploy` from infolis/infolis-datasets did not cause any leaks according to visualvm.
