### PR TITLE
solves issue of "patterns"=[null] entries in bootstrapping datastore dumps of luceneSearcher executions

### DIFF
--- a/src/main/java/io/github/infolis/algorithm/Bootstrapping.java
+++ b/src/main/java/io/github/infolis/algorithm/Bootstrapping.java
@@ -59,7 +59,7 @@ public abstract class Bootstrapping extends BaseAlgorithm implements BootstrapLe
         execution.setSearchTerm(seed);
         InfolisPattern termPattern = new InfolisPattern(RegexUtils.normalizeQuery(seed, true));
         DataStoreClient tempClient = getTempDataStoreClient();
-        tempClient.put(InfolisPattern.class, termPattern);
+        tempClient.post(InfolisPattern.class, termPattern);
         execution.setPatterns(Arrays.asList(termPattern.getUri()));
         execution.setInputFiles(getExecution().getInputFiles());
         execution.setReliabilityThreshold(getExecution().getReliabilityThreshold());
@@ -72,7 +72,6 @@ public abstract class Bootstrapping extends BaseAlgorithm implements BootstrapLe
         for (String uri : execution.getTextualReferences()) {
            	textualReferences.add(tempClient.get(TextualReference.class, uri));
         }
-        tempClient.clear();
         return textualReferences;
     }
 

--- a/src/main/java/io/github/infolis/algorithm/InfolisPatternSearcher.java
+++ b/src/main/java/io/github/infolis/algorithm/InfolisPatternSearcher.java
@@ -135,7 +135,6 @@ public class InfolisPatternSearcher extends BaseAlgorithm {
     		counter++;
     		updateProgress(counter, size);
     	}
-    	tempClient.clear();
         return validatedTextualReferences;
     }
 

--- a/src/main/java/io/github/infolis/algorithm/ReliabilityBasedBootstrapping.java
+++ b/src/main/java/io/github/infolis/algorithm/ReliabilityBasedBootstrapping.java
@@ -326,7 +326,6 @@ public class ReliabilityBasedBootstrapping extends Bootstrapping {
                     }
                 }
             }
-            tempClient.clear();
 	        // this returns only the most reliable patterns, not all reliable ones
             // thus, new seeds are generated based on the most reliable patterns only
             return this.topK;
@@ -422,7 +421,6 @@ public class ReliabilityBasedBootstrapping extends Bootstrapping {
             double summedConfidenceNewTopK = 0;
             if (firstIteration) {
             	this.topK = newTopK;
-            	tempClient.clear();
             	return this.topK;
             }
             else {
@@ -439,7 +437,6 @@ public class ReliabilityBasedBootstrapping extends Bootstrapping {
 	            }
 	            else this.topK = newTopK;
 	
-	            tempClient.clear();
 	            return this.topK;
             }
         }


### PR DESCRIPTION
- temporary patterns were added to the datastore using put instead of post -> null values as uris
- clearing the temporary stores is not necessary (but doesn't seem to hurt serialization)
