### PR TITLE
Query cache

### DIFF
--- a/src/main/java/io/github/infolis/algorithm/FederatedSearcher.java
+++ b/src/main/java/io/github/infolis/algorithm/FederatedSearcher.java
@@ -1,5 +1,6 @@
 package io.github.infolis.algorithm;
 
+import io.github.infolis.InfolisConfig;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.FileResolver;
 import io.github.infolis.model.ExecutionStatus;
@@ -7,12 +8,17 @@ import io.github.infolis.model.entity.Entity;
 import io.github.infolis.model.entity.SearchResult;
 import io.github.infolis.infolink.querying.QueryService;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +37,8 @@ public class FederatedSearcher extends BaseAlgorithm {
 
     @Override
     public void execute() throws IOException {
-        List<SearchResult> allResults = new ArrayList<>();
+        List<String> allResults = new ArrayList<>();
+        File cache = initializeCache();
 
         Entity entity = getInputDataStoreClient().get(Entity.class, getExecution().getLinkedEntities().get(0));
         int counter = 0, size =0;
@@ -54,9 +61,17 @@ public class FederatedSearcher extends BaseAlgorithm {
                     //TODO else?
                     getOutputDataStoreClient().post(QueryService.class, queryService);
                     debug(log, "Calling QueryService {} to find entity {}", queryService.getUri(), entity.getUri());
-                    List<SearchResult> results = queryService.find(entity);
-                    allResults.addAll(results);
-                    updateProgress(counter, size);
+                    String query = queryService.createQuery(entity).toString();
+	            	List<String> searchResultUris = readFromCache(cache, query);
+	            	
+	            	if (searchResultUris.isEmpty()) {
+		            	List<SearchResult> results = queryService.find(entity);
+		            	searchResultUris = getInputDataStoreClient().post(SearchResult.class, results);
+		                writeToCache(cache, query, searchResultUris);
+	            	}
+	            	if (!searchResultUris.isEmpty()) allResults.addAll(searchResultUris);
+	            	
+	                updateProgress(counter, size);
 
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -73,22 +88,62 @@ public class FederatedSearcher extends BaseAlgorithm {
                     }
                     //TODO else?
 	            	debug(log, "Calling QueryService {} to find entity {}", queryService.getUri(), entity.getUri());
-	            	List<SearchResult> results = queryService.find(entity);
-	                allResults.addAll(results);
+	            	String query = queryService.createQuery(entity).toString();
+	            	List<String> searchResultUris = readFromCache(cache, query);
+	            	if (searchResultUris.isEmpty()) {
+		            	List<SearchResult> results = queryService.find(entity);
+		            	searchResultUris = getInputDataStoreClient().post(SearchResult.class, results);
+		                writeToCache(cache, query, searchResultUris);
+	            	}
+	            	if (!searchResultUris.isEmpty()) allResults.addAll(searchResultUris);
+	            	
 	                updateProgress(counter, size);
             	}
             } catch (Exception e) {
                 e.printStackTrace();
             }
         }
-        getInputDataStoreClient().post(SearchResult.class, allResults);
-        List<String> searchResultUris = new ArrayList<>();
-        for (SearchResult sr : allResults) {
-            searchResultUris.add(sr.getUri());
-            log.debug("Found search result {}: {}", sr.getUri(), sr.getIdentifier());
+        
+        for (String uri : allResults) {
+            log.debug("Found search result {}", uri);
         }
-        getExecution().setSearchResults(searchResultUris);
+        getExecution().setSearchResults(allResults);
         getExecution().setStatus(ExecutionStatus.FINISHED);
+    }
+    
+    private File initializeCache() throws IOException {
+    	// TODO hack
+    	//return Files.createTempFile(InfolisConfig.getTmpFilePath(), "querycache", ".txt").toFile();
+    	return Paths.get(InfolisConfig.getTmpFilePath().toString(), "querycache").toFile();
+    }
+    
+    private void writeToCache(File cache, String query, List<String> uris) throws IOException {
+    	if (!cache.exists()) {
+    		log.debug("cache file does not exist, continuing without cache");
+    		return;
+    	}
+    	
+    	String entry = query + "@@@";
+    	for (String uri : uris) entry += uri + "!!!";
+    	FileUtils.write(cache, entry.substring(0, entry.length() - 3) + "\n", true);
+    	log.debug("wrote query to cache");
+    }
+    
+    private List<String> readFromCache(File cache, String query) throws IOException {
+    	if (!cache.exists()) {
+    		log.debug("cache file does not exist, continuing without cache");
+    		return new ArrayList<String>();
+    	}
+    	
+    	for (String line : FileUtils.readLines(cache)) {
+    		String[] entry = line.split("@@@");
+    		if (entry[0].equals(query)) {
+    			log.debug("found query in cache");
+    			return Arrays.asList(entry[1].split("!!!"));
+    		}
+    	}
+    	// query was not found in cache
+    	return new ArrayList<String>();
     }
 
     @Override

--- a/src/main/java/io/github/infolis/algorithm/FederatedSearcher.java
+++ b/src/main/java/io/github/infolis/algorithm/FederatedSearcher.java
@@ -38,8 +38,13 @@ public class FederatedSearcher extends BaseAlgorithm {
     @Override
     public void execute() throws IOException {
         List<String> allResults = new ArrayList<>();
-        File cache = initializeCache();
-
+        
+        File cache = null;
+        if (null != getExecution().getIndexDirectory() && !getExecution().getIndexDirectory().isEmpty()) {
+        	cache = new File(getExecution().getIndexDirectory());
+        	log.debug("using cache at " + getExecution().getIndexDirectory());
+        }
+        
         Entity entity = getInputDataStoreClient().get(Entity.class, getExecution().getLinkedEntities().get(0));
         int counter = 0, size =0;
         
@@ -111,15 +116,9 @@ public class FederatedSearcher extends BaseAlgorithm {
         getExecution().setStatus(ExecutionStatus.FINISHED);
     }
     
-    private File initializeCache() throws IOException {
-    	// TODO hack
-    	//return Files.createTempFile(InfolisConfig.getTmpFilePath(), "querycache", ".txt").toFile();
-    	return Paths.get(InfolisConfig.getTmpFilePath().toString(), "querycache").toFile();
-    }
-    
     private void writeToCache(File cache, String query, List<String> uris) throws IOException {
-    	if (!cache.exists()) {
-    		log.debug("cache file does not exist, continuing without cache");
+    	if (null == cache || !cache.exists()) {
+    		log.debug("no cache file given or cache file does not exist, continuing without cache");
     		return;
     	}
     	
@@ -130,8 +129,8 @@ public class FederatedSearcher extends BaseAlgorithm {
     }
     
     private List<String> readFromCache(File cache, String query) throws IOException {
-    	if (!cache.exists()) {
-    		log.debug("cache file does not exist, continuing without cache");
+    	if (null == cache || !cache.exists()) {
+    		log.debug("no cache file given or cache file does not exist, continuing without cache");
     		return new ArrayList<String>();
     	}
     	

--- a/src/main/java/io/github/infolis/algorithm/FederatedSearcher.java
+++ b/src/main/java/io/github/infolis/algorithm/FederatedSearcher.java
@@ -1,6 +1,5 @@
 package io.github.infolis.algorithm;
 
-import io.github.infolis.InfolisConfig;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.FileResolver;
 import io.github.infolis.model.ExecutionStatus;
@@ -12,8 +11,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
+++ b/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
@@ -1,12 +1,17 @@
 package io.github.infolis.algorithm;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.github.infolis.InfolisConfig;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.FileResolver;
 import io.github.infolis.model.Execution;
@@ -31,10 +36,16 @@ public class ReferenceLinker extends BaseAlgorithm {
 	
 	private static final Logger log = LoggerFactory.getLogger(ReferenceLinker.class);
 	
-	private List<String> resolveReferences(List<String> textualReferences) {
+	private List<String> resolveReferences(List<String> textualReferences) throws IOException {
     	List<String> entityLinks = new ArrayList<>();
     	List<String> queryServices = getExecution().getQueryServices();
         List<Class<? extends QueryService>> queryServiceClasses = getExecution().getQueryServiceClasses();
+        
+        //TODO hack
+        // create query cache
+        File cache = Paths.get(InfolisConfig.getTmpFilePath().toString(), "querycache").toFile();
+        // delete cache if it already exists
+        FileUtils.write(cache, "", false);
 
 	    for (String s : textualReferences) {
 	    	debug(log, "Resolving TextualReference " + s);
@@ -66,7 +77,6 @@ public class ReferenceLinker extends BaseAlgorithm {
         return entityUri;
     }
 
-    //TODO call referenceLinker on list of entites?
     public List<String> searchInRepositories(String entityUri, List<String> queryServices) {
         Execution searchRepo = getExecution().createSubExecution(FederatedSearcher.class);
         searchRepo.setSearchResultLinkerClass(getExecution().getSearchResultLinkerClass());
@@ -106,7 +116,7 @@ public class ReferenceLinker extends BaseAlgorithm {
 
     
 	@Override
-	public void execute() {
+	public void execute() throws IOException {
 		List<String> entityLinks = resolveReferences(getExecution().getTextualReferences());
 		getExecution().setLinks(entityLinks);
 	}

--- a/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
+++ b/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
@@ -3,6 +3,8 @@ package io.github.infolis.algorithm;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,8 +39,10 @@ public class ReferenceLinker extends BaseAlgorithm {
 	
 	private List<String> resolveReferences(List<String> textualReferences) throws IOException {
 		// create query cache
-		File cache = Files.createTempFile(InfolisConfig.getTmpFilePath(), "querycache", ".txt").toFile();
-		cache.deleteOnExit();
+		Path generalCachePath = Paths.get(InfolisConfig.getTmpFilePath().toString(), "cache");
+		if (!generalCachePath.toFile().exists()) Files.createDirectories(generalCachePath);
+		Path privateCachePath = Files.createTempDirectory(generalCachePath, Long.toString(System.nanoTime()));
+		File cache = Files.createTempFile(privateCachePath, "querycache", ".txt").toFile();
         String cachePath = cache.getCanonicalPath();
         
     	List<String> entityLinks = new ArrayList<>();
@@ -61,6 +65,8 @@ public class ReferenceLinker extends BaseAlgorithm {
 	        	entityLinks.addAll(createLinks(searchRes, s));
 	        }
 	    }
+	    cache.delete();
+		privateCachePath.toFile().delete();
 	    return entityLinks;
     }
 

--- a/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
+++ b/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
@@ -1,14 +1,11 @@
 package io.github.infolis.algorithm;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,7 +13,6 @@ import io.github.infolis.InfolisConfig;
 import io.github.infolis.datastore.DataStoreClient;
 import io.github.infolis.datastore.FileResolver;
 import io.github.infolis.model.Execution;
-import sun.security.util.Cache;
 import io.github.infolis.infolink.querying.QueryService;
 
 /**

--- a/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
+++ b/src/main/java/io/github/infolis/algorithm/ReferenceLinker.java
@@ -1,5 +1,6 @@
 package io.github.infolis.algorithm;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -36,7 +37,9 @@ public class ReferenceLinker extends BaseAlgorithm {
 	
 	private List<String> resolveReferences(List<String> textualReferences) throws IOException {
 		// create query cache
-        String cachePath = Files.createTempFile(InfolisConfig.getTmpFilePath(), "querycache", ".txt").toAbsolutePath().toString();
+		File cache = Files.createTempFile(InfolisConfig.getTmpFilePath(), "querycache", ".txt").toFile();
+		cache.deleteOnExit();
+        String cachePath = cache.getCanonicalPath();
         
     	List<String> entityLinks = new ArrayList<>();
     	List<String> queryServices = getExecution().getQueryServices();
@@ -58,7 +61,7 @@ public class ReferenceLinker extends BaseAlgorithm {
 	        	entityLinks.addAll(createLinks(searchRes, s));
 	        }
 	    }
-	return entityLinks;
+	    return entityLinks;
     }
 
     public String extractMetaData(String textualReference) {


### PR DESCRIPTION
"pragmatic" quick implementation.
- search queries made by FederatedSearcher are cached and reused for every call made by ReferenceLinker
- ReferenceLinker creates temporary file for caching
